### PR TITLE
Fix/iphoneos x86 64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,7 @@ set -e
 if [ "$2" == "clean" ]; then
     if [ "$1" == "ios" ]; then
         echo "Cleaning the iOS build directory..."
-        rm -rf build/iphoneos
-        rm -rf build/iphonesimulator
-        rm -rf build/ios
+        rm -rf build/apple
     elif [ "$1" == "android" ]; then
         echo "Cleaning the Android build directory..."
         rm -rf build/android

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,7 @@ if [ "$1" == "ios" ] || [ "$1" == "all" ]; then
     echo "Building iOS..."
     ./scripts/build_apple.sh iphoneos
     ./scripts/build_apple.sh iphonesimulator
+    ./scripts/build_apple.sh iphonesimulator-legacy
 
     echo "Creating xcframework..."
     ./scripts/create_xcframework.sh

--- a/scripts/build_apple.sh
+++ b/scripts/build_apple.sh
@@ -10,9 +10,12 @@ elif [ "$1" == "iphonesimulator" ]; then
     export SDK="iphonesimulator"
     export SYSTEM_NAME="iOS"
     export OSX_DEPLOYMENT_TARGET="13.0"
-    # It seems that iPhoneOS17.4 doesn't allow x86_64, only arm64
-    # Xcode 15.3 doesn't allow old build system to fix build failure when using arm64;x86_64: https://gitlab.kitware.com/cmake/cmake/-/issues/21282
-    export OSX_ARCHITECTURE="arm64" # TODO: Add x86_64 for older simulators?
+    export OSX_ARCHITECTURE="arm64"
+elif [ "$1" == "iphonesimulator-legacy" ]; then
+    export SDK="iphonesimulator"
+    export SYSTEM_NAME="iOS"
+    export OSX_DEPLOYMENT_TARGET="13.0"
+    export OSX_ARCHITECTURE="x86_64"
 elif [ "$1" == "macos" ]; then
     export SDK="macosx"
     export SYSTEM_NAME="Darwin"
@@ -63,6 +66,7 @@ cmake \
     -DProtobuf_PROTOC_EXECUTABLE=$PROTOBUF_LOCAL_DIR/bin/protoc \
     -DBoost_INCLUDE_DIR=/opt/homebrew/include \
     -DCMAKE_SYSTEM_NAME=$SYSTEM_NAME \
+    -DCMAKE_OSX_SYSROOT=$SDK \
     -DCMAKE_OSX_ARCHITECTURES=$OSX_ARCHITECTURE \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_DEPLOYMENT_TARGET \
     -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO \

--- a/scripts/build_apple.sh
+++ b/scripts/build_apple.sh
@@ -10,6 +10,8 @@ elif [ "$1" == "iphonesimulator" ]; then
     export SDK="iphonesimulator"
     export SYSTEM_NAME="iOS"
     export OSX_DEPLOYMENT_TARGET="13.0"
+    # It seems that iPhoneOS17.4 doesn't allow x86_64, only arm64
+    # Xcode 15.3 doesn't allow old build system to fix build failure when using arm64;x86_64: https://gitlab.kitware.com/cmake/cmake/-/issues/21282
     export OSX_ARCHITECTURE="arm64" # TODO: Add x86_64 for older simulators?
 elif [ "$1" == "macos" ]; then
     export SDK="macosx"

--- a/scripts/create_xcframework.sh
+++ b/scripts/create_xcframework.sh
@@ -34,7 +34,31 @@ libtool -static -o build/apple/arm64/iphonesimulator/libvalhalla_all.a \
     build/apple/arm64/iphonesimulator/wrapper/install/lib/libvalhalla-tyr.a \
     build/apple/arm64/iphonesimulator/wrapper/install/lib/libvalhalla-wrapper.a
 
+libtool -static -o build/apple/x86_64/iphonesimulator/libvalhalla_all.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libprotobuf-lite.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libtz.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-baldr.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-loki.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-meili.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-midgard.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-odin.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-proto.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-sif.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-skadi.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-thor.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-tyr.a \
+    build/apple/x86_64/iphonesimulator/wrapper/install/lib/libvalhalla-wrapper.a
+
+if [ ! -d "build/apple/arm64-x86_64/iphonesimulator" ]; then
+    mkdir -p build/apple/arm64-x86_64/iphonesimulator
+fi
+
+# Merge the two simulator libraries into one fat library
+lipo -create build/apple/arm64/iphonesimulator/libvalhalla_all.a build/apple/x86_64/iphonesimulator/libvalhalla_all.a \
+    -output build/apple/arm64-x86_64/iphonesimulator/libvalhalla_all.a
+
 xcodebuild -create-xcframework \
     -library build/apple/arm64/iphoneos/libvalhalla_all.a -headers build/apple/arm64/iphoneos/wrapper/install/include \
-    -library build/apple/arm64/iphonesimulator/libvalhalla_all.a -headers build/apple/arm64/iphoneos/wrapper/install/include \
+    -library build/apple/arm64-x86_64/iphonesimulator/libvalhalla_all.a -headers build/apple/arm64/iphoneos/wrapper/install/include \
     -output build/apple/valhalla-wrapper.xcframework


### PR DESCRIPTION
- Adds `DCMAKE_OSX_SYSROOT` to correct x86_64 iphonesimulator failure.
- Adds lipo command to merge iPhone simulator outputs on install.