### PR TITLE
Create application support dir if it does not yet exist

### DIFF
--- a/apple/Sources/Valhalla/ValhallaFileManager.swift
+++ b/apple/Sources/Valhalla/ValhallaFileManager.swift
@@ -13,7 +13,7 @@ enum ValhallaFileManager {
         guard let applicationDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             throw ValhallaFileManagerError.systemDirNotFound("applicationSupport")
         }
-        
+        try FileManager.default.createDirectory(at: applicationDir, withIntermediateDirectories: true)
         let configURL = applicationDir.appendingPathComponent("valhalla-config.json")
         let data = try JSONEncoder().encode(config)
 


### PR DESCRIPTION
The valhalla-mobile initialization requires the application support dir. This change makes sure it exists prior to writing the valhalla config to it.

Without this change, valhalla initialization failed for my test apps that had not yet written to the application support directory.