### PR TITLE
Support on-demand downloading of tiles via HTTP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/Rallista/valhalla-openapi-models-swift.git", .upToNextMinor(from: "0.1.0")),
+            url: "https://github.com/Rallista/valhalla-openapi-models-swift.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/UInt2048/Light-Swift-Untar.git", .upToNextMajor(from: "1.0.4")),
         .package(url: "https://github.com/apple/swift-docc-plugin", .upToNextMajor(from: "1.0.0")),
     ],

--- a/apple/Sources/Valhalla/Extensions/ValhallaConfig.swift
+++ b/apple/Sources/Valhalla/Extensions/ValhallaConfig.swift
@@ -88,7 +88,7 @@ extension ValhallaConfig {
     ///
     /// This injects a tile folder path into the default valhalla config.
     ///
-    /// - Parameter tileExtractTar: The local folder path URL for the tiles directory.
+    /// - Parameter tilesDir: The local folder path URL for the tiles directory.
     public init(tilesDir: URL) throws {
         let defaultConfig = ValhallaConfig.loadDefault()
         
@@ -98,6 +98,38 @@ extension ValhallaConfig {
         self.init(additionalData: defaultConfig.additionalData,
                   httpd: defaultConfig.httpd,
                   loki: defaultConfig.loki,
+                  meili: defaultConfig.meili,
+                  mjolnir: mjolnir,
+                  odin: defaultConfig.odin,
+                  serviceLimits: defaultConfig.serviceLimits,
+                  statsd: defaultConfig.statsd,
+                  thor: defaultConfig.thor)
+    }
+    
+    
+    /// Initialize ValhallaConfig for a specific tiles_url and tiles directory.
+    ///
+    /// Use this to download tiles from a http server on demand, and store them in the specified directory
+    ///
+    /// - Parameters:
+    ///  - tilesUrl: The Url pattern which will be used to download the tiles. Valhalla will look for the {tilePath} portion of the url and fill this out with a given tile path when it make a request for that tile.
+    ///  - tilesAreGzFiles: If true, the downloaded files will be treated as gz-compressed tiles files
+    ///  - tilesDir: The local folder path URL where the downloaded tiles will be stored
+    public init(tilesUrl: String, tilesDir: URL, tilesAreGzFiles: Bool = false) throws {
+        let defaultConfig = ValhallaConfig.loadDefault()
+        
+        var mjolnir = defaultConfig.mjolnir
+        mjolnir?.tileUrl = tilesUrl
+        mjolnir?.tileUrlGz = tilesAreGzFiles
+        mjolnir?.tileDir = tilesDir.relativePath
+        
+        var loki = defaultConfig.loki
+        // When tiles are downloaded on demand, the connectivity map will not work
+        loki?.useConnectivity = false
+        
+        self.init(additionalData: defaultConfig.additionalData,
+                  httpd: defaultConfig.httpd,
+                  loki: loki,
                   meili: defaultConfig.meili,
                   mjolnir: mjolnir,
                   odin: defaultConfig.odin,

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -24,6 +24,7 @@ public:
             
             NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsurl];
             request.HTTPMethod = @"GET";
+            request.timeoutInterval = 10;
             
             // Set range header if needed
             if (range_size > 0) {
@@ -78,6 +79,7 @@ public:
             
             NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsurl];
             request.HTTPMethod = @"HEAD";
+            request.timeoutInterval = 10;
             
             NSHTTPURLResponse* httpResponse = nil;
             NSError* error = nil;

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -1,6 +1,122 @@
 #import "ValhallaWrapper.h"
 
 #import <include/main.h>
+#import <Foundation/Foundation.h>
+
+/**
+ * iOS implementation of ValhallaMobileHttpClient using NSMutableURLRequest
+ */
+class ValhallaMobileHttpClientImpl : public ValhallaMobileHttpClient {
+public:
+    valhalla::baldr::tile_getter_t::GET_response_t 
+    get(const std::string& url, uint64_t range_offset = 0, uint64_t range_size = 0) override {
+        valhalla::baldr::tile_getter_t::GET_response_t response;
+        
+        @autoreleasepool {
+            NSString* urlString = [NSString stringWithUTF8String:url.c_str()];
+            NSURL* nsurl = [NSURL URLWithString:urlString];
+            
+            if (!nsurl) {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+                response.http_code_ = 0;
+                return response;
+            }
+            
+            NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsurl];
+            request.HTTPMethod = @"GET";
+            
+            // Set range header if needed
+            if (range_size > 0) {
+                NSString* rangeHeader = [NSString stringWithFormat:@"bytes=%llu-%llu", 
+                                                  range_offset, range_offset + range_size - 1];
+                [request setValue:rangeHeader forHTTPHeaderField:@"Range"];
+            }
+            
+            NSHTTPURLResponse* httpResponse = nil;
+            NSError* error = nil;
+            
+            NSData* data = [NSURLConnection sendSynchronousRequest:request 
+                                                  returningResponse:&httpResponse 
+                                                              error:&error];
+            
+            if (error || !httpResponse) {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+                response.http_code_ = httpResponse ? httpResponse.statusCode : 0;
+                return response;
+            }
+            
+            response.http_code_ = httpResponse.statusCode;
+            
+            if (httpResponse.statusCode >= 200 && httpResponse.statusCode < 300) {
+                // Copy data to response bytes
+                if (data) {
+                    const char* dataBytes = static_cast<const char*>(data.bytes);
+                    response.bytes_.assign(dataBytes, dataBytes + data.length);
+                }
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::SUCCESS;
+            } else {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+            }
+        }
+        
+        return response;
+    }
+    
+    valhalla::baldr::tile_getter_t::HEAD_response_t 
+    head(const std::string& url, valhalla::baldr::tile_getter_t::header_mask_t header_mask) override {
+        valhalla::baldr::tile_getter_t::HEAD_response_t response;
+        
+        @autoreleasepool {
+            NSString* urlString = [NSString stringWithUTF8String:url.c_str()];
+            NSURL* nsurl = [NSURL URLWithString:urlString];
+            
+            if (!nsurl) {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+                response.http_code_ = 0;
+                return response;
+            }
+            
+            NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsurl];
+            request.HTTPMethod = @"HEAD";
+            
+            NSHTTPURLResponse* httpResponse = nil;
+            NSError* error = nil;
+            
+            [NSURLConnection sendSynchronousRequest:request 
+                                  returningResponse:&httpResponse 
+                                              error:&error];
+            
+            if (error || !httpResponse) {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+                response.http_code_ = httpResponse ? httpResponse.statusCode : 0;
+                return response;
+            }
+            
+            response.http_code_ = httpResponse.statusCode;
+            
+            if (httpResponse.statusCode >= 200 && httpResponse.statusCode < 300) {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::SUCCESS;
+                
+                // Extract Last-Modified header if requested
+                if (header_mask & valhalla::baldr::tile_getter_t::kHeaderLastModified) {
+                    NSString* lastModified = [httpResponse valueForHTTPHeaderField:@"Last-Modified"];
+                    if (lastModified) {
+                        NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
+                        formatter.dateFormat = @"EEE, dd MMM yyyy HH:mm:ss zzz";
+                        formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+                        NSDate* date = [formatter dateFromString:lastModified];
+                        response.last_modified_time_ = (uint64_t)[date timeIntervalSince1970];
+                    }
+                }
+            } else {
+                response.status_ = valhalla::baldr::tile_getter_t::status_code_t::FAILURE;
+            }
+        }
+        
+        return response;
+    }
+};
+
 
 @implementation ValhallaWrapper
 
@@ -9,7 +125,9 @@
     self = [super init];
     std::string path = std::string([config_path UTF8String]);
     try {
-        _actor = create_valhalla_actor(path.c_str());
+        // Create the network interface implementation for iOS
+        ValhallaMobileHttpClient* httpClient = new ValhallaMobileHttpClientImpl();
+        _actor = create_valhalla_actor(path.c_str(), httpClient);
     } catch (NSException *exception) {
         *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:@{
             NSUnderlyingErrorKey: exception,

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -108,6 +108,8 @@ public:
                         formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
                         NSDate* date = [formatter dateFromString:lastModified];
                         response.last_modified_time_ = (uint64_t)[date timeIntervalSince1970];
+                    } else {
+                        response.last_modified_time_ = 0;
                     }
                 }
             } else {

--- a/src/wrapper/include/main.h
+++ b/src/wrapper/include/main.h
@@ -23,7 +23,7 @@ JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv
 #elif __APPLE__
 
 std::string route(const char *request, void* actor);
-void* create_valhalla_actor(const char *config_path);
+void* create_valhalla_actor(const char *config_path, ValhallaMobileHttpClient* http_client = nullptr);
 void delete_valhalla_actor(void* actor);
 
 #endif

--- a/src/wrapper/include/valhalla_actor.h
+++ b/src/wrapper/include/valhalla_actor.h
@@ -3,12 +3,38 @@
 
 #include <string>
 #include <valhalla/tyr/actor.h>
+#include <valhalla/baldr/tilegetter.h>
+
+class ValhallaMobileHttpClient {
+public:
+    virtual ~ValhallaMobileHttpClient() = default;
+    
+    /**
+     * Makes a synchronous GET request to fetch tile data
+     * @param url the URL to fetch
+     * @param range_offset optional offset for range requests
+     * @param range_size optional size for range requests
+     * @return GET_response_t with the response data and status
+     */
+    virtual valhalla::baldr::tile_getter_t::GET_response_t 
+    get(const std::string& url, uint64_t range_offset = 0, uint64_t range_size = 0) = 0;
+    
+    /**
+     * Makes a synchronous HEAD request to fetch response headers
+     * @param url the URL to query
+     * @param header_mask mask for which headers to retrieve
+     * @return HEAD_response_t with the response headers and status
+     */
+    virtual valhalla::baldr::tile_getter_t::HEAD_response_t 
+    head(const std::string& url, valhalla::baldr::tile_getter_t::header_mask_t header_mask) = 0;
+};
 
 class ValhallaActor {
 private:
-    valhalla::tyr::actor_t actor;
+    std::unique_ptr<valhalla::tyr::actor_t> actor;
+    std::unique_ptr<valhalla::baldr::GraphReader> graph_reader;
 public:
-    ValhallaActor(const std::string& config_path);
+    ValhallaActor(const std::string& config_path, ValhallaMobileHttpClient* http_client = nullptr);
     
     std::string route(const std::string& request);
 };

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -45,8 +45,8 @@ Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv *env,
 }
 
 #elif __APPLE__
-void* create_valhalla_actor(const char *config_path) {
-    return new ValhallaActor(config_path);
+void* create_valhalla_actor(const char *config_path, ValhallaMobileHttpClient* http_client) {
+    return new ValhallaActor(config_path, http_client);
 }
 
 void delete_valhalla_actor(void* actor) {

--- a/src/wrapper/valhalla_actor.cpp
+++ b/src/wrapper/valhalla_actor.cpp
@@ -4,25 +4,75 @@
 #include <valhalla/loki/worker.h>
 #include "valhalla_actor.h"
 
-ValhallaActor::ValhallaActor(const std::string& config_path): actor([&config_path]() {
-    // Get the config path
-    std::string config_file(config_path);
+class TileGetterWrapper : public valhalla::baldr::tile_getter_t {
+public:
+  /**
+   * @param pool_size  the number of curler instances in the pool
+   * @param user_agent  user agent to use by curlers for HTTP requests
+   * @param gzipped  whether to request for gzip compressed data
+   * @param user_pw  the "user:pwd" for HTTP basic auth
+   */
+  TileGetterWrapper(ValhallaMobileHttpClient* http_client, bool is_gzipped): http_client(http_client), is_gzipped(is_gzipped) {
+  }
+
+  GET_response_t get(const std::string& url,
+                     const uint64_t range_offset = 0,
+                     const uint64_t range_size = 0) override {
+    GET_response_t result;
+    if (http_client) { 
+        result = http_client->get(url, range_offset, range_size);
+    } else {
+        result.status_ = tile_getter_t::status_code_t::FAILURE;
+    }
+    return result;
+  }
+
+  HEAD_response_t head(const std::string& url, header_mask_t header_mask) override {
+    HEAD_response_t result;
+    if (http_client) { 
+        result = http_client->head(url, header_mask);
+    } else {
+        result.status_ = tile_getter_t::status_code_t::FAILURE;
+    }
+    return result;
+  }
+
+  bool gzipped() const override {
+    return is_gzipped;
+  }
+
+  ~TileGetterWrapper() {
+    delete http_client;
+  };
+
+private:
+  bool is_gzipped;
+  ValhallaMobileHttpClient* http_client;
+};
+
+
+ValhallaActor::ValhallaActor(const std::string& config_path, ValhallaMobileHttpClient* http_client) {
+std::string config_file(config_path);
     
     // Set up the config object
     boost::property_tree::ptree config;
     rapidjson::read_json(config_file, config);
-    
+
+    auto mjolnir_config = config.get_child("mjolnir");
+    graph_reader = std::make_unique<valhalla::baldr::GraphReader>(
+      mjolnir_config, 
+      std::make_unique<TileGetterWrapper>(http_client, mjolnir_config.get<bool>("tile_url_gz", false))
+    );
     // Setup the actor
-    return valhalla::tyr::actor_t(config, true);
-}()) // IIFE to prepare actor
-{}
+    actor = std::make_unique<valhalla::tyr::actor_t>(config, *graph_reader, true);
+}
 
 std::string ValhallaActor::route(const std::string& request) {
     // Convert the request to a std::string
     std::string req = std::string(request);
     
     // Produce the route result
-    std::string result = actor.route(req);
+    std::string result = actor->route(req);
     
     return result;
 }


### PR DESCRIPTION
I added support for the parameter tile_url of valhalla/mjolnir. 

I did not want to link libcurl, since I don't know whether this will cause issues during the app store review process, and since it increases the library size.
Instead, I added the possibility to define a custom http client for each os, and added an implementation for iOS using NSMutableURLRequest.

This PR depends on a [PR to valhalla-openapi-models-swift](https://github.com/Rallista/valhalla-openapi-models-swift/pull/7).

Please let me know what you think and if you would like changes.