### PR TITLE
Expose locate action; make ValhallaError public

### DIFF
--- a/apple/Sources/Valhalla/Errors/ValhallaError.swift
+++ b/apple/Sources/Valhalla/Errors/ValhallaError.swift
@@ -1,6 +1,17 @@
 import Foundation
 
-enum ValhallaError: Error, Hashable {
+public enum ValhallaError: Error, Hashable {
     case encodingNotUtf8(String)
     case valhallaError(Int, String)
+}
+
+extension ValhallaError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .encodingNotUtf8(let context):
+            return "Encoding error (not UTF-8): \(context)"
+        case .valhallaError(let code, let message):
+            return "Valhalla error \(code): \(message)"
+        }
+    }
 }

--- a/apple/Sources/Valhalla/Valhalla.swift
+++ b/apple/Sources/Valhalla/Valhalla.swift
@@ -59,4 +59,18 @@ public final class Valhalla: ValhallaProviding {
     public func route(rawRequest request: String) -> String {
         actor!.route(request)
     }
+
+    /// Pass-through to Valhalla's locate action. Request body is the
+    /// standard locate JSON (see
+    /// https://github.com/valhalla/valhalla/blob/master/docs/docs/api/locate/api-reference.md).
+    /// Returns the locate response JSON as a string — typically a JSON
+    /// array, one entry per input location, each carrying an `edges[]`
+    /// list. Pass `verbose: true` in the request to include
+    /// `edge_info.shape` (the edge's graph-exact polyline at precision 6),
+    /// which is what consumers like GhostRoute need to construct
+    /// `linear_cost_factors` shapes that pass the engine's exact
+    /// edge-walker (Thor RouteMatcher::FormPath).
+    public func locate(rawRequest request: String) -> String {
+        actor!.locate(request)
+    }
 }

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -154,10 +154,19 @@ public:
     @synchronized(self) {
         // Convert the NSString to std::string
         std::string req = std::string([request UTF8String]);
-        
+
         // Generate the valhalla response
         std::string res = route(req.c_str(), _actor);
-        
+
+        return [NSString stringWithUTF8String:res.c_str()];
+    }
+}
+
+- (NSString*)locate:(NSString*)request
+{
+    @synchronized(self) {
+        std::string req = std::string([request UTF8String]);
+        std::string res = locate(req.c_str(), _actor);
         return [NSString stringWithUTF8String:res.c_str()];
     }
 }

--- a/apple/Sources/ValhallaObjc/include/ValhallaWrapper.h
+++ b/apple/Sources/ValhallaObjc/include/ValhallaWrapper.h
@@ -13,6 +13,7 @@
 - (instancetype)initWithConfigPath:(NSString*)config_path error:(__autoreleasing NSError **)error;
 
 - (NSString*)route:(NSString*)request;
+- (NSString*)locate:(NSString*)request;
 
 @end
 

--- a/apple/Tests/ValhallaTests/TestValhallaWithFolder.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithFolder.swift
@@ -21,7 +21,7 @@ final class TestValhallaWithFolder: XCTestCase {
                 RoutingWaypoint(lat: 45.869701, lon: -123.766121)
             ],
             costing: .auto,
-            units: .mi,
+            units: .mi
         )
         
         do {
@@ -42,7 +42,7 @@ final class TestValhallaWithFolder: XCTestCase {
                 RoutingWaypoint(lat: 42.5086, lon: 1.5394)
             ],
             costing: .auto,
-            units: .mi,
+            units: .mi
         )
         
         let response = try valhalla.route(request: request)

--- a/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
@@ -25,7 +25,7 @@ final class TestValhallaWithTar: XCTestCase {
                     RoutingWaypoint(lat: 42.5086, lon: 1.5394)
                 ],
                 costing: .auto,
-                units: .mi,
+                units: .mi
             )
         
             let _ = try valhalla.route(request: request)
@@ -45,7 +45,7 @@ final class TestValhallaWithTar: XCTestCase {
                 RoutingWaypoint(lat: 45.869701, lon: -123.766121)
             ],
             costing: .auto,
-            units: .mi,
+            units: .mi
         )
         
         do {
@@ -66,7 +66,7 @@ final class TestValhallaWithTar: XCTestCase {
                 RoutingWaypoint(lat: 42.5086, lon: 1.5394)
             ],
             costing: .auto,
-            units: .mi,
+            units: .mi
         )
         
         let response = try valhalla.route(request: request)

--- a/src/wrapper/include/main.h
+++ b/src/wrapper/include/main.h
@@ -23,6 +23,7 @@ JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv
 #elif __APPLE__
 
 std::string route(const char *request, void* actor);
+std::string locate(const char *request, void* actor);
 void* create_valhalla_actor(const char *config_path, ValhallaMobileHttpClient* http_client = nullptr);
 void delete_valhalla_actor(void* actor);
 

--- a/src/wrapper/include/valhalla_actor.h
+++ b/src/wrapper/include/valhalla_actor.h
@@ -37,6 +37,7 @@ public:
     ValhallaActor(const std::string& config_path, ValhallaMobileHttpClient* http_client = nullptr);
     
     std::string route(const std::string& request);
+    std::string locate(const std::string& request);
 };
 
 #endif // VALHALLAACTOR_H

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -73,4 +73,25 @@ std::string route(const char *request, void* actor) {
 
     return result;
 }
+
+std::string locate(const char *request, void* actor) {
+    std::string result;
+    try {
+        result = ((ValhallaActor*) actor)->locate(request);
+    } catch (const valhalla::valhalla_exception_t &err) {
+        printf("[ValhallaActor] locate valhalla_exception: %s\n", err.what());
+        std::string code = std::to_string(err.code);
+        std::string message = err.message.c_str();
+
+        result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
+    } catch (const std::exception &err) {
+        printf("[ValhallaActor] locate std::exception: %s\n", err.what());
+        result = "{\"code\":-1,\"message\":\"" + std::string(err.what()) + "\"}";
+    } catch (...) {
+        printf("[ValhallaActor] locate unknown exception");
+        result = "{\"code\":-1,\"message\":\"unknown exception\"}";
+    }
+
+    return result;
+}
 #endif

--- a/src/wrapper/valhalla_actor.cpp
+++ b/src/wrapper/valhalla_actor.cpp
@@ -70,9 +70,19 @@ std::string config_file(config_path);
 std::string ValhallaActor::route(const std::string& request) {
     // Convert the request to a std::string
     std::string req = std::string(request);
-    
+
     // Produce the route result
     std::string result = actor->route(req);
-    
+
+    return result;
+}
+
+std::string ValhallaActor::locate(const std::string& request) {
+    // Mirrors route() exactly. Valhalla's tyr::actor_t::locate accepts
+    // a list of locations and returns a JSON array (one entry per input
+    // location) with the candidate graph edges for each. See
+    // https://github.com/valhalla/valhalla/blob/master/docs/docs/api/locate/api-reference.md
+    std::string req = std::string(request);
+    std::string result = actor->locate(req);
     return result;
 }


### PR DESCRIPTION
Adds the `locate` Valhalla action to the Swift / Obj-C / C-glue
wrapper, and makes the `ValhallaError` enum public with
`LocalizedError` conformance.

## locate

Mirrors the existing `route` plumbing exactly: a method on
`ValhallaActor`, a C entry point in `main.cpp`, an Obj-C method on
`ValhallaWrapper`, and a public Swift `func locate(rawRequest:)`.
The underlying call is `valhalla::tyr::actor_t::locate` which
already exists upstream — no Valhalla source changes required.

Refs Rallista/valhalla-mobile#53 (Consider what can be contributed
back to Valhalla).

## ValhallaError public

Currently the enum is internal, so consumers can't pattern-match
the cases — they have to use `Mirror` reflection to extract the
code/message associated values. Marking it `public` plus a
`LocalizedError` conformance gives compile-checked error handling.

No behavior changes; pure access-level widening + a small extension.
Existing Mirror-based workarounds continue to compile.

## Swift 6.0.3 (Xcode 16.2) test compat (drive-by)

Second commit drops 5 trailing commas in `TestValhallaWithFolder.swift`
and `TestValhallaWithTar.swift` that prevent the test target from
compiling on Xcode 16.2 (Swift 6.0.3). Trailing commas in argument
lists are a Swift 6.1 feature (SE-0286). Cosmetic change; happy to
drop this commit if you prefer main to stay on the bleeding-edge
toolchain only.

## Verification

Smoke-tested end-to-end against the bundled Andorra fixture
(`apple/Tests/ValhallaTests/TestData/valhalla_tiles.tar`):

```
---- locate(Andorra 42.5063, 1.5218) ----
Locations returned: 1
Edges in first:     3
Edges with shape:   3
First shape:        }ckapA{f{{ASf@Oh@…
** TEST SUCCEEDED **
```

Also built and integrated into the consumer app — the new entry
point flows through the full bridge stack (Swift → Obj-C → C → C++)
and returns the expected JSON array of edges carrying `edge_info.shape`
polylines.

cc @chrstnbwnkl @nilsnolde