### PR TITLE
Only attach the HTTP tile-getter when tile_url is set (fix loose-tile crash on missing tiles)

### DIFF
--- a/src/wrapper/valhalla_actor.cpp
+++ b/src/wrapper/valhalla_actor.cpp
@@ -59,9 +59,25 @@ std::string config_file(config_path);
     rapidjson::read_json(config_file, config);
 
     auto mjolnir_config = config.get_child("mjolnir");
+    // Only attach the HTTP tile-getter when a tile_url is configured. Passing a
+    // getter unconditionally forces GraphReader into fetch mode, so in pure
+    // loose-tile mode (tile_dir set, tile_url empty) a referenced-but-missing
+    // tile attempts a remote fetch against an empty URL and throws
+    // (std::exception: basic_string) instead of returning nullptr. With a null
+    // getter, GraphReader::GetGraphTile returns nullptr for a missing loose tile
+    // (`if (!tile_getter_) return nullptr;`) — matching upstream Valhalla, so the
+    // router routes around the gap. This is what offline tile_dir consumers
+    // expect (e.g. region packs that don't bundle the full tile hierarchy).
+    std::unique_ptr<TileGetterWrapper> tile_getter;
+    if (!mjolnir_config.get<std::string>("tile_url", std::string()).empty()) {
+      tile_getter = std::make_unique<TileGetterWrapper>(
+          http_client, mjolnir_config.get<bool>("tile_url_gz", false));
+    } else if (http_client) {
+      // Not handed to a getter (which would own it) — release it so it doesn't leak.
+      delete http_client;
+    }
     graph_reader = std::make_unique<valhalla::baldr::GraphReader>(
-      mjolnir_config, 
-      std::make_unique<TileGetterWrapper>(http_client, mjolnir_config.get<bool>("tile_url_gz", false))
+      mjolnir_config, std::move(tile_getter)
     );
     // Setup the actor
     actor = std::make_unique<valhalla::tyr::actor_t>(config, *graph_reader, true);


### PR DESCRIPTION
## Problem

In pure loose-tile mode (`mjolnir.tile_dir` set, `tile_url` empty), routing through a `tile_dir` that is missing a *referenced* tile **crashes** with `std::exception: basic_string` (logged as `Downloading tile N from ` with an empty URL) instead of routing around the gap.

This bites any offline consumer whose `tile_dir` doesn't contain every referenced tile — e.g. region/buffered tile packs that don't bundle the full continent hierarchy. A long route's hierarchical search references a far L0 connector tile; if it's absent, the app hard-crashes.

## Cause

`ValhallaActor`'s constructor **always** hands the `GraphReader` a `TileGetterWrapper`, regardless of `tile_url`. That forces the reader into fetch mode, so for a missing loose tile `GraphReader::GetGraphTile` takes the URL-fetch path and calls the getter with an empty `tile_url_` → throws.

Upstream Valhalla only constructs a tile-getter when `tile_url` is non-empty; `GetGraphTile` then returns `nullptr` for a missing loose tile (`if (!tile_getter_) return nullptr;`), and the router routes around it.

## Fix

Only attach the `TileGetterWrapper` when `tile_url` is configured. When it isn't, pass a null getter and release the `http_client` we were handed (the wrapper would otherwise own/free it).

## Verified

On-device: routing a path that references a tile absent from the loose `tile_dir` now routes around it (no crash). Fetch mode (with `tile_url`) is unchanged.