### PR TITLE
Escape the JSON error payload, and stop invalid UTF-8 from crashing the app

### DIFF
--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -152,13 +152,19 @@ public:
 - (NSString*)route:(NSString*)request
 {
     @synchronized(self) {
-        // Convert the NSString to std::string
-        std::string req = std::string([request UTF8String]);
-        
-        // Generate the valhalla response
-        std::string res = route(req.c_str(), _actor);
-        
-        return [NSString stringWithUTF8String:res.c_str()];
+        std::string res = route([request UTF8String], _actor);
+
+        // Not stringWithUTF8String:, which returns nil on invalid UTF-8 and
+        // would trap: the header has no nullability annotations, so Swift
+        // imports this as a non-optional String. Road names come straight out
+        // of the graph tiles, so a corrupt tile pack is a real source of bad
+        // bytes. This also skips a strlen over a response that can run to
+        // megabytes.
+        NSString* response = [[NSString alloc] initWithBytes:res.data()
+                                                      length:res.size()
+                                                    encoding:NSUTF8StringEncoding];
+
+        return response ?: @"{\"code\":-1,\"message\":\"response was not valid UTF-8\"}";
     }
 }
 

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -3,6 +3,45 @@
 #include "main.h"
 #include "valhalla_actor.h"
 
+#include <cstdio>
+#include <string>
+
+// Escape a string for embedding in the JSON error payload below.
+//
+// The message is not always ours.
+// Valhalla copies caller-supplied text into it verbatim:
+// an unrecognised action name becomes error 144 carrying that name
+// (src/valhalla/src/worker.cc:1192, src/valhalla/src/exceptions.cc:172).
+// A quote or a control character in there would produce a document
+// the platform layer cannot parse,
+// so the real error would be lost behind a decoding failure.
+static std::string escape_json(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size() + 16);
+
+    for (unsigned char c : value) {
+        switch (c) {
+            case '"':  escaped += "\\\""; break;
+            case '\\': escaped += "\\\\"; break;
+            case '\b': escaped += "\\b";  break;
+            case '\f': escaped += "\\f";  break;
+            case '\n': escaped += "\\n";  break;
+            case '\r': escaped += "\\r";  break;
+            case '\t': escaped += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    char unicode[7];
+                    snprintf(unicode, sizeof(unicode), "\\u%04x", c);
+                    escaped += unicode;
+                } else {
+                    escaped += static_cast<char>(c);
+                }
+        }
+    }
+
+    return escaped;
+}
+
 #ifdef __ANDROID__
 // The Android JNI interface uses a different function signature.
 #include <jni.h>
@@ -27,14 +66,13 @@ Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv *env,
     } catch (const valhalla::valhalla_exception_t &err) {
         printf("[ValhallaActor] route valhalla_exception: %s\n", err.what());
         std::string code = std::to_string(err.code);
-        std::string message = err.message.c_str();
 
-        result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
+        result = "{\"code\":" + code + ",\"message\":\"" + escape_json(err.message) + "\"}";
     } catch (const std::exception &err) {
         printf("[ValhallaActor] route std::exception: %s\n", err.what());
-        result = "{\"code\":-1,\"message\":\"" + std::string(err.what()) + "\"}";
+        result = "{\"code\":-1,\"message\":\"" + escape_json(err.what()) + "\"}";
     } catch (...) {
-        printf("[ValhallaActor] route unknown exception");
+        printf("[ValhallaActor] route unknown exception\n");
         result = "{\"code\":-1,\"message\":\"unknown exception\"}";
     }
 
@@ -60,14 +98,13 @@ std::string route(const char *request, void* actor) {
     } catch (const valhalla::valhalla_exception_t &err) {
         printf("[ValhallaActor] route valhalla_exception: %s\n", err.what());
         std::string code = std::to_string(err.code);
-        std::string message = err.message.c_str();
 
-        result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
+        result = "{\"code\":" + code + ",\"message\":\"" + escape_json(err.message) + "\"}";
     } catch (const std::exception &err) {
         printf("[ValhallaActor] route std::exception: %s\n", err.what());
-        result = "{\"code\":-1,\"message\":\"" + std::string(err.what()) + "\"}";
+        result = "{\"code\":-1,\"message\":\"" + escape_json(err.what()) + "\"}";
     } catch (...) {
-        printf("[ValhallaActor] route unknown exception");
+        printf("[ValhallaActor] route unknown exception\n");
         result = "{\"code\":-1,\"message\":\"unknown exception\"}";
     }
 

--- a/src/wrapper/valhalla_actor.cpp
+++ b/src/wrapper/valhalla_actor.cpp
@@ -84,11 +84,5 @@ std::string config_file(config_path);
 }
 
 std::string ValhallaActor::route(const std::string& request) {
-    // Convert the request to a std::string
-    std::string req = std::string(request);
-    
-    // Produce the route result
-    std::string result = actor->route(req);
-    
-    return result;
+    return actor->route(request);
 }


### PR DESCRIPTION
Three small robustness fixes on the paths in and out of `route`. Independent of
each other and of any feature work, so I split them out of a larger branch to
keep this easy to look at.

## The error message is not escaped

The error object is assembled by string concatenation with the message
interpolated raw:

```cpp
result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
```

The message is not always ours. Valhalla copies caller-supplied text into it
verbatim, so an unrecognised action name comes back inside error 144
(`src/worker.cc:1192`, then `src/exceptions.cc:172` appends it). A request
carrying a quote, a backslash, or a control character therefore produces a
document the platform layer cannot parse, and the real error is lost behind a
decoding failure. A newline also forges a line in the adjacent `printf`.

Both platforms had their own copy of the ladder, so both are fixed by a
file-local helper.

On the Android hunk: I have no NDK here, so I cannot give you a real Android
build. What I did check is that the JNI branch still compiles with the new
calls, by defining `__ANDROID__` against a stub `jni.h` and confirming the
preprocessor took that branch. It is clean. What that does not cover is the
NDK's own headers and the instrumented tests. If you would rather keep this
Apple-only, I will drop those two lines.

## Invalid UTF-8 crashes instead of erroring

`stringWithUTF8String:` returns nil for invalid UTF-8. `ValhallaWrapper.h` has
no nullability annotations, so Swift imports the method as returning a
non-optional `String`, and a nil traps in the host app rather than surfacing an
error. Road names come straight out of the graph tiles, so a corrupt tile pack
is a plausible source. It now returns an error payload. Building the string
from bytes rather than a C string also skips a `strlen` over a response that
can run to megabytes.

## Every request is copied for no reason

`ValhallaActor::route` deep-copied its argument into a local before passing it
to an `actor_t` method that takes `const std::string&`. AGENTS.md is explicit
that copies across this boundary are what to avoid on a constrained phone.

Existing suite passes unchanged, six tests.

*AI-assisted, authored with Claude and reviewed by @tristanpinto.*
