### PR TITLE
Add `trace_route` and `trace_attributes` to Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 
 This project builds [valhalla](https://github.com/valhalla/valhalla) as a static iOS or shared Android library.
 
-It currently only exposes the route function for the primary purpose of generating turn by turn navigation routes
-using a downloaded pre-parsed valhalla tileset.
+It currently exposes valhalla's `route` action, for the primary purpose of generating turn by turn navigation
+routes using a downloaded pre-parsed valhalla tileset, along with the two map matching actions — `trace_route`,
+which snaps a GPS trace to the road network and returns a route along it, and `trace_attributes`, which returns
+the attributes of every edge the trace matched. Like routing, both run entirely against the tiles on the device.
 
 We welcome contributions to expand the functionality of this library. See our [CONTRIBUTING.md](CONTRIBUTING.md)
 for more information.

--- a/android/valhalla/docs/Valhalla.md
+++ b/android/valhalla/docs/Valhalla.md
@@ -25,3 +25,45 @@ val request =
 // Fetch a route from Valhalla
 val response = valhalla.route(request)
 ```
+
+## Map matching
+
+The same instance also snaps a recorded GPS trace onto the road network, against the tiles already on
+the device. Supply the trace either as a list of `MapMatchWaypoint`s or as an encoded polyline — note
+that the polyline must use six digits of precision rather than the usual five.
+
+Use `traceRoute` when you want a route along the matched path:
+
+```kt
+val response = valhalla.traceRoute(
+    MapMatchRequest(
+        shape =
+            listOf(
+                MapMatchWaypoint(lat = 42.5063, lon = 1.5218),
+                MapMatchWaypoint(lat = 42.5074, lon = 1.5301),
+                MapMatchWaypoint(lat = 42.5086, lon = 1.5394)),
+        costing = MapMatchCostingModel.auto))
+
+println(response.trip.statusMessage)
+```
+
+Use `traceAttributes` when you want the road network itself — edge identifiers, road classes, speeds,
+names — rather than turn by turn directions. Narrow the response with `filters`; by default valhalla
+returns every attribute it has, which is a lot of JSON for a long trace:
+
+```kt
+val response = valhalla.traceAttributes(
+    TraceAttributesRequest(
+        encodedPolyline = polyline6,
+        costing = MapMatchCostingModel.auto,
+        filters =
+            TraceAttributeFilterOptions(
+                attributes = listOf(TraceAttributeKey.edgePeriodSpeed, TraceAttributeKey.edgePeriodNames),
+                action = TraceAttributeFilterOptions.Action.include)))
+
+response.edges?.forEach { println(it.names) }
+```
+
+Both actions report engine failures — including a trace that cannot be matched — as
+`ValhallaException.Internal`. Formats other than valhalla's own JSON are reachable through
+`traceRouteRaw` and `traceAttributesRaw`, which return the response body unparsed.

--- a/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaActorTest.kt
+++ b/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaActorTest.kt
@@ -90,6 +90,10 @@ class ValhallaActorTest {
     assertEquals("Found route between points", trip.getString("status_message"))
   }
 
+  /**
+   * The trace is the exact shape of a prior route, so Valhalla walks the edges instead of running
+   * Meili, and there are no matched_points — [testMapSnapTraceAttributes] covers those.
+   */
   @Test
   fun testSuccessfulTraceAttributes() {
     val valhalla = ValhallaActor(configPath)
@@ -105,6 +109,24 @@ class ValhallaActorTest {
 
     assertTrue(
         "expected matched edges in: $response", responseJson.getJSONArray("edges").length() > 0)
+    assertFalse("expected no matched points in: $response", responseJson.has("matched_points"))
+  }
+
+  /** The map-snapping path is the one that reports how each input point matched. */
+  @Test
+  fun testMapSnapTraceAttributes() {
+    val valhalla = ValhallaActor(configPath)
+
+    val request =
+        JSONObject()
+            .put("encoded_polyline", routeShape(valhalla))
+            .put("costing", "auto")
+            .put("shape_match", "map_snap")
+            .toString()
+    val response = valhalla.traceAttributes(request)
+
+    val responseJson = JSONObject(response)
+
     assertTrue(
         "expected matched points in: $response",
         responseJson.getJSONArray("matched_points").length() > 0)

--- a/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaActorTest.kt
+++ b/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaActorTest.kt
@@ -59,4 +59,75 @@ class ValhallaActorTest {
     assertEquals(0, trip.getInt("status"))
     assertEquals("Found route between points", trip.getString("status_message"))
   }
+
+  /**
+   * The shape of a known-good route through the fixture, taken from the engine itself so that the
+   * trace assertions below are about map matching rather than about how well some hand-picked
+   * coordinates happen to sit on an Andorran road.
+   */
+  private fun routeShape(valhalla: ValhallaActor): String {
+    val request =
+        "{\"locations\":[{\"lat\":42.5063,\"lon\":1.5218},{\"lat\":42.5086,\"lon\":1.5394}],\"costing\":\"auto\",\"units\":\"miles\"}"
+    val trip = JSONObject(valhalla.route(request)).getJSONObject("trip")
+
+    return trip.getJSONArray("legs").getJSONObject(0).getString("shape")
+  }
+
+  @Test
+  fun testSuccessfulTraceRoute() {
+    val valhalla = ValhallaActor(configPath)
+
+    val request =
+        JSONObject()
+            .put("encoded_polyline", routeShape(valhalla))
+            .put("costing", "auto")
+            .toString()
+    val response = valhalla.traceRoute(request)
+
+    val trip = JSONObject(response).getJSONObject("trip")
+
+    assertEquals(0, trip.getInt("status"))
+    assertEquals("Found route between points", trip.getString("status_message"))
+  }
+
+  @Test
+  fun testSuccessfulTraceAttributes() {
+    val valhalla = ValhallaActor(configPath)
+
+    val request =
+        JSONObject()
+            .put("encoded_polyline", routeShape(valhalla))
+            .put("costing", "auto")
+            .toString()
+    val response = valhalla.traceAttributes(request)
+
+    val responseJson = JSONObject(response)
+
+    assertTrue(
+        "expected matched edges in: $response", responseJson.getJSONArray("edges").length() > 0)
+    assertTrue(
+        "expected matched points in: $response",
+        responseJson.getJSONArray("matched_points").length() > 0)
+  }
+
+  /** The trace actions report failures through the same envelope [route] does. */
+  @Test
+  fun testTraceRouteNoConfigPath() {
+    val valhalla = ValhallaActor("invalid.json")
+
+    val request = "{\"encoded_polyline\":\"abc\",\"costing\":\"auto\"}"
+    val response = valhalla.traceRoute(request)
+
+    assertEquals(response, "{\"code\":-1,\"message\":\"Cannot open file invalid.json\"}")
+  }
+
+  @Test
+  fun testTraceAttributesNoConfigPath() {
+    val valhalla = ValhallaActor("invalid.json")
+
+    val request = "{\"encoded_polyline\":\"abc\",\"costing\":\"auto\"}"
+    val response = valhalla.traceAttributes(request)
+
+    assertEquals(response, "{\"code\":-1,\"message\":\"Cannot open file invalid.json\"}")
+  }
 }

--- a/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaTraceTest.kt
+++ b/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaTraceTest.kt
@@ -83,9 +83,14 @@ class ValhallaTraceTest {
     assertTrue("expected at least one matched leg", response.trip.legs.isNotEmpty())
   }
 
+  /**
+   * The same Oregon coordinates the routing tests use to miss the Andorra fixture.
+   *
+   * The code is not pinned: it depends on how far the matcher gets before giving up, since Loki can
+   * reject the locations outright and Meili can fail to find a path.
+   */
   @Test
   fun test_traceRoute_noSuitableEdges() {
-    // The same Oregon coordinates the routing tests use to miss the Andorra fixture.
     val request =
         MapMatchRequest(
             shape =
@@ -94,9 +99,6 @@ class ValhallaTraceTest {
                     MapMatchWaypoint(lat = 45.869701, lon = -123.766121)),
             costing = MapMatchCostingModel.auto)
 
-    // Which code comes back depends on how far the matcher gets before giving up — Loki can
-    // reject the locations outright, or Meili can fail to find a path — so assert that the
-    // engine reported a failure rather than pinning a code that is not ours to guarantee.
     val exception = assertThrows(ValhallaException::class.java) { valhalla.traceRoute(request) }
 
     assertTrue(
@@ -146,6 +148,7 @@ class ValhallaTraceTest {
     assertNotNull("expected the matched shape", response.shape)
   }
 
+  /** Only the requested attributes come back, so the shape is absent from the response. */
   @Test
   fun test_traceAttributes_filtered() {
     val request =
@@ -164,7 +167,6 @@ class ValhallaTraceTest {
     val edges = response.edges
     assertNotNull("expected matched edges", edges)
     assertTrue("expected at least one matched edge", edges!!.isNotEmpty())
-    // Only the requested attributes come back; the shape was not among them.
     assertEquals(null, response.shape)
   }
 

--- a/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaTraceTest.kt
+++ b/android/valhalla/src/androidTest/java/com/valhalla/valhalla/ValhallaTraceTest.kt
@@ -1,0 +1,194 @@
+package com.valhalla.valhalla
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.valhalla.api.models.CostingModel
+import com.valhalla.api.models.DirectionsOptions
+import com.valhalla.api.models.MapMatchCostingModel
+import com.valhalla.api.models.MapMatchRequest
+import com.valhalla.api.models.MapMatchWaypoint
+import com.valhalla.api.models.RouteRequest
+import com.valhalla.api.models.RoutingWaypoint
+import com.valhalla.api.models.TraceAttributeFilterOptions
+import com.valhalla.api.models.TraceAttributeKey
+import com.valhalla.api.models.TraceAttributesRequest
+import com.valhalla.config.ValhallaConfigBuilder
+import com.valhalla.valhalla.config.ValhallaConfigManager
+import com.valhalla.valhalla.files.ValhallaFile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the map-matching actions against the bundled Andorra tile extract.
+ *
+ * The traces here are not hand-written coordinates: each test first asks Valhalla for a route
+ * between two points known to be covered by the fixture, then feeds that route's shape back in as
+ * the trace. The shape comes off the graph itself, so it matches the road network exactly and the
+ * tests assert on matching rather than on how faithfully some invented coordinates happen to sit on
+ * an Andorran road.
+ */
+@RunWith(AndroidJUnit4::class)
+class ValhallaTraceTest {
+
+  private lateinit var appContext: Context
+  private lateinit var configManager: ValhallaConfigManager
+  private lateinit var valhalla: Valhalla
+
+  @Before
+  fun setUp() {
+    appContext = InstrumentationRegistry.getInstrumentation().targetContext
+    configManager = ValhallaConfigManager(appContext)
+
+    val tarFile = ValhallaFile.usingAsset(appContext, "valhalla_tiles.tar")
+    val config = ValhallaConfigBuilder().withTileExtract(tarFile.absolutePath()).build()
+
+    valhalla = Valhalla(appContext, config, configManager)
+  }
+
+  /**
+   * The shape of a known-good route through the fixture, as a polyline with six digits of
+   * precision — which is what the trace actions expect.
+   */
+  private fun routeShape(): String {
+    val request =
+        RouteRequest(
+            locations =
+                listOf(
+                    RoutingWaypoint(lat = 42.5063, lon = 1.5218),
+                    RoutingWaypoint(lat = 42.5086, lon = 1.5394)),
+            costing = CostingModel.auto,
+            format = RouteRequest.Format.json)
+
+    return when (val response = valhalla.route(request)) {
+      is ValhallaResponse.Json -> response.jsonResponse.trip.legs.first().shape
+      is ValhallaResponse.Osrm -> throw AssertionError("format should not be osrm")
+    }
+  }
+
+  @Test
+  fun test_traceRoute_success() {
+    val request =
+        MapMatchRequest(encodedPolyline = routeShape(), costing = MapMatchCostingModel.auto)
+
+    val response = valhalla.traceRoute(request)
+
+    assertEquals(0, response.trip.status)
+    assertEquals("Found route between points", response.trip.statusMessage)
+    assertTrue("expected at least one matched leg", response.trip.legs.isNotEmpty())
+  }
+
+  @Test
+  fun test_traceRoute_noSuitableEdges() {
+    // The same Oregon coordinates the routing tests use to miss the Andorra fixture.
+    val request =
+        MapMatchRequest(
+            shape =
+                listOf(
+                    MapMatchWaypoint(lat = 45.843812, lon = -123.768205),
+                    MapMatchWaypoint(lat = 45.869701, lon = -123.766121)),
+            costing = MapMatchCostingModel.auto)
+
+    // Which code comes back depends on how far the matcher gets before giving up — Loki can
+    // reject the locations outright, or Meili can fail to find a path — so assert that the
+    // engine reported a failure rather than pinning a code that is not ours to guarantee.
+    val exception = assertThrows(ValhallaException::class.java) { valhalla.traceRoute(request) }
+
+    assertTrue(
+        "expected a Valhalla error, got: ${exception.message}",
+        exception is ValhallaException.Internal)
+  }
+
+  @Test
+  fun test_traceRoute_osrmFormatNotSupported() {
+    val request =
+        MapMatchRequest(
+            encodedPolyline = routeShape(),
+            costing = MapMatchCostingModel.auto,
+            directionsOptions = DirectionsOptions(format = DirectionsOptions.Format.osrm))
+
+    assertThrows(ValhallaException.NotSupported::class.java) { valhalla.traceRoute(request) }
+  }
+
+  /**
+   * The OSRM response the typed API refuses is still reachable raw, and — importantly — is not
+   * mistaken for an error. A successful OSRM map match carries a top-level `"code": "Ok"` and
+   * reports its routes under `matchings`, which is exactly the shape a naive error check trips
+   * over.
+   */
+  @Test
+  fun test_traceRouteRaw_osrmFormat() {
+    val requestJson =
+        """{"encoded_polyline":${quote(routeShape())},"costing":"auto","format":"osrm"}"""
+
+    val rawResponse = valhalla.traceRouteRaw(requestJson)
+
+    assertTrue("expected osrm matchings, got: $rawResponse", rawResponse.contains("\"matchings\""))
+    assertTrue(
+        "expected osrm tracepoints, got: $rawResponse", rawResponse.contains("\"tracepoints\""))
+  }
+
+  @Test
+  fun test_traceAttributes_success() {
+    val request =
+        TraceAttributesRequest(encodedPolyline = routeShape(), costing = MapMatchCostingModel.auto)
+
+    val response = valhalla.traceAttributes(request)
+
+    val edges = response.edges
+    assertNotNull("expected matched edges", edges)
+    assertTrue("expected at least one matched edge", edges!!.isNotEmpty())
+    assertNotNull("expected the matched shape", response.shape)
+  }
+
+  @Test
+  fun test_traceAttributes_filtered() {
+    val request =
+        TraceAttributesRequest(
+            encodedPolyline = routeShape(),
+            costing = MapMatchCostingModel.auto,
+            filters =
+                TraceAttributeFilterOptions(
+                    attributes =
+                        listOf(
+                            TraceAttributeKey.edgePeriodSpeed, TraceAttributeKey.edgePeriodNames),
+                    action = TraceAttributeFilterOptions.Action.include))
+
+    val response = valhalla.traceAttributes(request)
+
+    val edges = response.edges
+    assertNotNull("expected matched edges", edges)
+    assertTrue("expected at least one matched edge", edges!!.isNotEmpty())
+    // Only the requested attributes come back; the shape was not among them.
+    assertEquals(null, response.shape)
+  }
+
+  @Test
+  fun test_traceAttributes_noSuitableEdges() {
+    val request =
+        TraceAttributesRequest(
+            shape =
+                listOf(
+                    MapMatchWaypoint(lat = 45.843812, lon = -123.768205),
+                    MapMatchWaypoint(lat = 45.869701, lon = -123.766121)),
+            costing = MapMatchCostingModel.auto)
+
+    val exception =
+        assertThrows(ValhallaException::class.java) { valhalla.traceAttributes(request) }
+
+    assertTrue(
+        "expected a Valhalla error, got: ${exception.message}",
+        exception is ValhallaException.Internal)
+  }
+
+  /** Encoded polylines contain backslashes, so they cannot be pasted into JSON unescaped. */
+  private fun quote(value: String): String {
+    val escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
+    return "\"$escaped\""
+  }
+}

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
@@ -139,8 +139,7 @@ class Valhalla(
     val encodedRequest = moshi.adapter(MapMatchRequest::class.java).toJson(request)
     val rawResponse = traceRouteRaw(encodedRequest)
 
-    return moshi.adapter(MapMatchRouteResponse::class.java).fromJson(rawResponse)
-        ?: throw ValhallaException.InvalidResponse()
+    return decodeResponse(rawResponse, MapMatchRouteResponse::class.java)
   }
 
   /**
@@ -169,8 +168,7 @@ class Valhalla(
     val encodedRequest = moshi.adapter(TraceAttributesRequest::class.java).toJson(request)
     val rawResponse = traceAttributesRaw(encodedRequest)
 
-    return moshi.adapter(TraceAttributesResponse::class.java).fromJson(rawResponse)
-        ?: throw ValhallaException.InvalidResponse()
+    return decodeResponse(rawResponse, TraceAttributesResponse::class.java)
   }
 
   /**
@@ -201,19 +199,37 @@ class Valhalla(
   }
 
   /**
+   * Decodes [rawResponse] into [type].
+   *
+   * Moshi's own failures are reported as [ValhallaException.InvalidResponse], with the parse error
+   * kept as the cause. Letting a `JsonDataException` escape would break the documented contract of
+   * the trace methods, and would leave a caller unable to tell "the engine said no" apart from "we
+   * could not read what it said".
+   */
+  private fun <T> decodeResponse(rawResponse: String, type: Class<T>): T =
+      try {
+        moshi.adapter(type).fromJson(rawResponse) ?: throw ValhallaException.InvalidResponse()
+      } catch (e: JsonDataException) {
+        throw ValhallaException.InvalidResponse(e)
+      } catch (e: IOException) {
+        throw ValhallaException.InvalidResponse(e)
+      }
+
+  /**
    * Returns [rawResponse] unchanged, unless it is the native wrapper's error envelope — in which
    * case the error it carries is thrown.
+   *
+   * A [JsonDataException] means the response is not the envelope, because it carries other keys or
+   * its `code` is not an int. An [IOException] means malformed JSON, which is left to the caller's
+   * decode so the problem is reported against the shape actually expected.
    */
   private fun checkForError(rawResponse: String): String {
     val error =
         try {
           errorAdapter.fromJson(rawResponse)
         } catch (e: JsonDataException) {
-          // Not the envelope: either it carries other keys, or `code` is not an int.
           null
         } catch (e: IOException) {
-          // Malformed JSON. Leave it to the caller's decode, which reports the problem
-          // against the shape actually expected rather than against the error envelope.
           null
         }
 

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
@@ -2,12 +2,19 @@ package com.valhalla.valhalla
 
 import android.content.Context
 import com.osrm.api.models.RouteResponse as OsrmRouteResponse
+import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.valhalla.api.models.DirectionsOptions
+import com.valhalla.api.models.MapMatchRequest
+import com.valhalla.api.models.MapMatchRouteResponse
 import com.valhalla.api.models.RouteRequest
 import com.valhalla.api.models.RouteResponse
+import com.valhalla.api.models.TraceAttributesRequest
+import com.valhalla.api.models.TraceAttributesResponse
 import com.valhalla.config.models.ValhallaConfig
 import com.valhalla.valhalla.config.ValhallaConfigManager
+import java.io.IOException
 
 /**
  * Main entry point for the Valhalla routing engine on Android.
@@ -39,6 +46,18 @@ class Valhalla(
     valhallaConfigManager.writeConfig(config)
     valhallaActor = ValhallaActor(valhallaConfigManager.getAbsolutePath())
   }
+
+  /**
+   * Adapter for the error envelope the native wrapper produces for every failure:
+   * `{"code": <int>, "message": "<string>"}`.
+   *
+   * `failOnUnknown` is what makes that envelope identifiable. It rejects any object carrying a key
+   * beyond those two, and every successful Valhalla payload carries several, so a response either
+   * is the envelope or is not. The substring test [route] uses cannot be reused for the trace
+   * actions: a successful OSRM map-match response also has a top-level `"code"`, and it reports its
+   * routes under `matchings` rather than `routes`, so it would be misread as an error.
+   */
+  private val errorAdapter = moshi.adapter(ErrorResponse::class.java).failOnUnknown()
 
   /**
    * Fetch a route from Valhalla.
@@ -88,5 +107,117 @@ class Valhalla(
         ValhallaResponse.Json(valhallaResponse)
       }
     }
+  }
+
+  /**
+   * Map-match a GPS trace onto the road network and return a route along the matched path.
+   *
+   * This is Valhalla's `trace_route` action. Supply the trace either as
+   * [MapMatchRequest.shape] or as a [MapMatchRequest.encodedPolyline] — note that the polyline
+   * must be encoded with six digits of precision rather than the usual five.
+   *
+   * Everything runs against the tiles already on the device, so this works with no network.
+   *
+   * @param request The trace to match, the costing model, and how to match it.
+   * @return The matched trip.
+   * @throws ValhallaException.Internal if the Valhalla engine returns an error response, which
+   *   includes the case where the trace cannot be matched to the road network.
+   * @throws ValhallaException.InvalidResponse if the response JSON cannot be parsed.
+   * @throws ValhallaException.NotSupported if the request asks for a format other than JSON.
+   *   OSRM map-match responses report their routes under `matchings`, a shape `osrm-openapi` does
+   *   not model, and GPX and PBF are not JSON at all — reach all three through [traceRouteRaw].
+   * @see MapMatchRequest
+   * @see traceAttributes
+   */
+  fun traceRoute(request: MapMatchRequest): MapMatchRouteResponse {
+    when (request.directionsOptions?.format) {
+      null,
+      DirectionsOptions.Format.json -> Unit
+      else -> throw ValhallaException.NotSupported()
+    }
+
+    val encodedRequest = moshi.adapter(MapMatchRequest::class.java).toJson(request)
+    val rawResponse = traceRouteRaw(encodedRequest)
+
+    return moshi.adapter(MapMatchRouteResponse::class.java).fromJson(rawResponse)
+        ?: throw ValhallaException.InvalidResponse()
+  }
+
+  /**
+   * Map-match a GPS trace onto the road network and return the attributes of every edge along the
+   * matched path.
+   *
+   * This is Valhalla's `trace_attributes` action. Use it instead of [traceRoute] when you need the
+   * road network itself — edge identifiers, road classes, speeds, names — rather than turn-by-turn
+   * directions. Narrow the response with [TraceAttributesRequest.filters]; by default Valhalla
+   * returns every attribute it has, which is a lot of JSON for a long trace.
+   *
+   * Everything runs against the tiles already on the device, so this works with no network.
+   *
+   * Unlike [traceRoute], this action always answers with Valhalla's own JSON — a `format` on the
+   * request's directions options is ignored rather than rejected.
+   *
+   * @param request The trace to match, the costing model, and which attributes to return.
+   * @return The matched edges, points, and the admins they reference.
+   * @throws ValhallaException.Internal if the Valhalla engine returns an error response, which
+   *   includes the case where the trace cannot be matched to the road network.
+   * @throws ValhallaException.InvalidResponse if the response JSON cannot be parsed.
+   * @see TraceAttributesRequest
+   * @see traceRoute
+   */
+  fun traceAttributes(request: TraceAttributesRequest): TraceAttributesResponse {
+    val encodedRequest = moshi.adapter(TraceAttributesRequest::class.java).toJson(request)
+    val rawResponse = traceAttributesRaw(encodedRequest)
+
+    return moshi.adapter(TraceAttributesResponse::class.java).fromJson(rawResponse)
+        ?: throw ValhallaException.InvalidResponse()
+  }
+
+  /**
+   * Run a `trace_route` request supplied as JSON and return the raw response.
+   *
+   * This is the escape hatch for response formats [MapMatchRouteResponse] cannot model, and for
+   * request options the generated models do not yet carry.
+   *
+   * @param requestJson A `trace_route` request as JSON.
+   * @return The raw response body, in whichever format the request asked for.
+   * @throws ValhallaException.Internal if the Valhalla engine returns an error response.
+   * @see traceRoute
+   */
+  fun traceRouteRaw(requestJson: String): String {
+    return checkForError(valhallaActor.traceRoute(requestJson))
+  }
+
+  /**
+   * Run a `trace_attributes` request supplied as JSON and return the raw response.
+   *
+   * @param requestJson A `trace_attributes` request as JSON.
+   * @return The raw JSON response body.
+   * @throws ValhallaException.Internal if the Valhalla engine returns an error response.
+   * @see traceAttributes
+   */
+  fun traceAttributesRaw(requestJson: String): String {
+    return checkForError(valhallaActor.traceAttributes(requestJson))
+  }
+
+  /**
+   * Returns [rawResponse] unchanged, unless it is the native wrapper's error envelope — in which
+   * case the error it carries is thrown.
+   */
+  private fun checkForError(rawResponse: String): String {
+    val error =
+        try {
+          errorAdapter.fromJson(rawResponse)
+        } catch (e: JsonDataException) {
+          // Not the envelope: either it carries other keys, or `code` is not an int.
+          null
+        } catch (e: IOException) {
+          // Malformed JSON. Leave it to the caller's decode, which reports the problem
+          // against the shape actually expected rather than against the error envelope.
+          null
+        }
+
+    error?.let { throw ValhallaException.Internal(it) }
+    return rawResponse
   }
 }

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
@@ -156,6 +156,11 @@ class Valhalla(
    * Unlike [traceRoute], this action always answers with Valhalla's own JSON — a `format` on the
    * request's directions options is ignored rather than rejected.
    *
+   * Exclude `matched.edge_index` through [TraceAttributesRequest.filters] when matching with
+   * `map_snap`. Valhalla never populates that field for this action, so it emits the `size_t`
+   * sentinel — 18446744073709551615 — which does not fit in a `Long`, and the whole response
+   * becomes undecodable rather than just that one field.
+   *
    * @param request The trace to match, the costing model, and which attributes to return.
    * @return The matched edges, points, and the admins they reference.
    * @throws ValhallaException.Internal if the Valhalla engine returns an error response, which

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/Valhalla.kt
@@ -157,9 +157,11 @@ class Valhalla(
    * request's directions options is ignored rather than rejected.
    *
    * Exclude `matched.edge_index` through [TraceAttributesRequest.filters] when matching with
-   * `map_snap`. Valhalla never populates that field for this action, so it emits the `size_t`
-   * sentinel — 18446744073709551615 — which does not fit in a `Long`, and the whole response
-   * becomes undecodable rather than just that one field.
+   * `map_snap`. Valhalla leaves that field unpopulated for some matched points while still
+   * reporting a valid edge id, so it emits the `size_t` sentinel — 18446744073709551615 — which
+   * does not fit in a `Long`, and the whole response becomes undecodable rather than just that one
+   * field. Tracked upstream as valhalla/valhalla#3699, with a fix proposed in
+   * valhalla/valhalla#6278.
    *
    * @param request The trace to match, the costing model, and which attributes to return.
    * @return The matched edges, points, and the admins they reference.

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaActor.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaActor.kt
@@ -2,6 +2,10 @@ package com.valhalla.valhalla
 
 internal interface ValhallaActorProviding {
   fun route(request: String): String
+
+  fun traceRoute(request: String): String
+
+  fun traceAttributes(request: String): String
 }
 
 /**
@@ -22,5 +26,27 @@ internal class ValhallaActor(private val configPath: String) : ValhallaActorProv
    */
   override fun route(request: String): String {
     return valhallaKotlin.route(request, configPath)
+  }
+
+  /**
+   * Run a `trace_route` request, map-matching a GPS trace onto the road network and returning a
+   * route along the matched path. Same assumptions as [route].
+   *
+   * @param request
+   * @return
+   */
+  override fun traceRoute(request: String): String {
+    return valhallaKotlin.traceRoute(request, configPath)
+  }
+
+  /**
+   * Run a `trace_attributes` request, map-matching a GPS trace onto the road network and returning
+   * the attributes of every edge along the matched path. Same assumptions as [route].
+   *
+   * @param request
+   * @return
+   */
+  override fun traceAttributes(request: String): String {
+    return valhallaKotlin.traceAttributes(request, configPath)
   }
 }

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaException.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaException.kt
@@ -21,7 +21,17 @@ sealed class ValhallaException(message: String? = null, cause: Throwable? = null
 
   class InvalidError : ValhallaException("Invalid error response data")
 
-  class InvalidResponse : ValhallaException("Invalid response data")
+  /**
+   * The engine answered, but the answer could not be read as the response type that was expected.
+   *
+   * @constructor Carries the underlying parse failure when there was one, so a caller can tell a
+   *   malformed payload from one whose shape has drifted from the models.
+   */
+  class InvalidResponse : ValhallaException {
+    constructor() : super("Invalid response data")
+
+    constructor(cause: Throwable) : super("Invalid response data", cause)
+  }
 
   class NotSupported : ValhallaException("The format is not currently supported")
 }

--- a/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaKotlin.kt
+++ b/android/valhalla/src/main/java/com/valhalla/valhalla/ValhallaKotlin.kt
@@ -8,4 +8,8 @@ internal class ValhallaKotlin {
   }
 
   external fun route(request: String, configPath: String): String
+
+  external fun traceRoute(request: String, configPath: String): String
+
+  external fun traceAttributes(request: String, configPath: String): String
 }

--- a/apple/Sources/Valhalla/Valhalla.docc/Valhalla.md
+++ b/apple/Sources/Valhalla/Valhalla.docc/Valhalla.md
@@ -5,8 +5,8 @@ Swift wrapper for the Valhalla routing engine.
 ## Overview
 
 The `valhalla-mobile` library builds libvalhalla c++ for iOS (and Android). It provides a Swift 
-interface to access the `ValhallaActor`. Currently, it only supports fetching routes through the 
-but with additional swift contributions, more features can be added.
+interface to access the `ValhallaActor`. It currently supports fetching routes and map matching 
+a recorded GPS trace, but with additional swift contributions, more features can be added.
 
 ## Getting Started
 
@@ -99,6 +99,52 @@ do {
     print("Error calculating route: \(error)")
 }
 ``` 
+
+### Map matching a GPS trace
+
+The same instance snaps a recorded GPS trace onto the road network, against the tiles already on
+the device. Supply the trace either as a list of `MapMatchWaypoint`s or as an encoded polyline —
+note that the polyline must use six digits of precision rather than the usual five.
+
+Use ``Valhalla/traceRoute(request:)`` when you want a route along the matched path:
+
+```swift
+let request = MapMatchRequest(
+    shape: [
+        MapMatchWaypoint(lat: 42.5063, lon: 1.5218),
+        MapMatchWaypoint(lat: 42.5074, lon: 1.5301),
+        MapMatchWaypoint(lat: 42.5086, lon: 1.5394)
+    ],
+    costing: .auto
+)
+
+let response = try valhalla.traceRoute(request: request)
+print("Matched \(response.trip.legs.count) leg(s)")
+```
+
+Use ``Valhalla/traceAttributes(request:)`` when you want the road network itself — edge identifiers,
+road classes, speeds, names — rather than turn by turn directions. Narrow the response with
+`filters`; by default valhalla returns every attribute it has, which is a lot of JSON for a long
+trace:
+
+```swift
+let request = TraceAttributesRequest(
+    encodedPolyline: polyline6,
+    costing: .auto,
+    filters: TraceAttributeFilterOptions(
+        attributes: [.edgePeriodSpeed, .edgePeriodNames],
+        action: .include
+    )
+)
+
+let response = try valhalla.traceAttributes(request: request)
+for edge in response.edges ?? [] {
+    print(edge.names ?? [])
+}
+```
+
+Formats other than valhalla's own JSON are reachable through ``Valhalla/traceRoute(rawRequest:)``
+and ``Valhalla/traceAttributes(rawRequest:)``, which return the response body unparsed.
 
 ## Topics
 

--- a/apple/Sources/Valhalla/Valhalla.swift
+++ b/apple/Sources/Valhalla/Valhalla.swift
@@ -74,9 +74,11 @@ public final class Valhalla: ValhallaProviding {
     /// - Note: This action always answers with Valhalla's own JSON. The `format` option
     ///   does not apply to it.
     /// - Important: Exclude `matched.edge_index` from the request's `filters` when matching with
-    ///   `shapeMatch: .mapSnap`. Valhalla never populates that field for this action, so it emits
-    ///   the `size_t` sentinel — 18446744073709551615 — which no signed 64-bit type can hold, and
-    ///   the whole response becomes undecodable rather than just that one field.
+    ///   `shapeMatch: .mapSnap`. Valhalla leaves that field unpopulated for some matched points
+    ///   while still reporting a valid edge id, so it emits the `size_t` sentinel —
+    ///   18446744073709551615 — which no signed 64-bit type can hold, and the whole response
+    ///   becomes undecodable rather than just that one field. Tracked upstream as
+    ///   valhalla/valhalla#3699, with a fix proposed in valhalla/valhalla#6278.
     /// - Parameter request: the trace to match, the costing model, and which attributes to return.
     /// - Returns: the matched edges, points, and the admins they reference.
     /// - Throws: ``ValhallaError/valhallaError(_:_:)`` when Valhalla rejects the request or

--- a/apple/Sources/Valhalla/Valhalla.swift
+++ b/apple/Sources/Valhalla/Valhalla.swift
@@ -73,6 +73,10 @@ public final class Valhalla: ValhallaProviding {
     ///
     /// - Note: This action always answers with Valhalla's own JSON. The `format` option
     ///   does not apply to it.
+    /// - Important: Exclude `matched.edge_index` from the request's `filters` when matching with
+    ///   `shapeMatch: .mapSnap`. Valhalla never populates that field for this action, so it emits
+    ///   the `size_t` sentinel — 18446744073709551615 — which no signed 64-bit type can hold, and
+    ///   the whole response becomes undecodable rather than just that one field.
     /// - Parameter request: the trace to match, the costing model, and which attributes to return.
     /// - Returns: the matched edges, points, and the admins they reference.
     /// - Throws: ``ValhallaError/valhallaError(_:_:)`` when Valhalla rejects the request or

--- a/apple/Sources/Valhalla/Valhalla.swift
+++ b/apple/Sources/Valhalla/Valhalla.swift
@@ -3,12 +3,16 @@ import ValhallaModels
 import ValhallaConfigModels
 
 public protocol ValhallaProviding {
-    
+
     init(_ config: ValhallaConfig) throws
-    
+
     init(configPath: String) throws
 
     func route(request: RouteRequest) throws -> RouteResponse
+
+    func traceRoute(request: MapMatchRequest) throws -> MapMatchRouteResponse
+
+    func traceAttributes(request: TraceAttributesRequest) throws -> TraceAttributesResponse
 }
 
 public final class Valhalla: ValhallaProviding {
@@ -37,26 +41,92 @@ public final class Valhalla: ValhallaProviding {
             throw ValhallaError.valhallaError(-1, error.localizedDescription)
         }
     }
-    
+
     public func route(request: RouteRequest) throws -> RouteResponse {
-        let requestData = try JSONEncoder().encode(request)
-        guard let requestStr = String(data: requestData, encoding: .utf8) else {
-            throw ValhallaError.encodingNotUtf8("requestStr")
-        }
-        
-        let resultStr = route(rawRequest: requestStr)
-        guard let resultData = resultStr.data(using: .utf8) else {
-            throw ValhallaError.encodingNotUtf8("resultData")
-        }
-        
-        if let error = try? JSONDecoder().decode(ValhallaErrorModel.self, from: resultData) {
-            throw ValhallaError.valhallaError(error.code, error.message)
-        }
-        
-        return try JSONDecoder().decode(RouteResponse.self, from: resultData)
+        try perform(request) { self.route(rawRequest: $0) }
+    }
+
+    /// Map-matches a GPS trace onto the road network and returns a route along the matched path.
+    ///
+    /// The trace is supplied either as `shape` or as an `encodedPolyline`
+    /// (with six digits of precision, not the usual five).
+    ///
+    /// - Note: Only Valhalla's own JSON response is decodable here.
+    ///   A request whose `directionsOptions.format` asks for `osrm`, `gpx`, or `pbf`
+    ///   produces a payload that ``MapMatchRouteResponse`` cannot represent —
+    ///   use ``traceRoute(rawRequest:)`` for those.
+    /// - Parameter request: the trace to match, the costing model, and how to match it.
+    /// - Returns: the matched trip.
+    /// - Throws: ``ValhallaError/valhallaError(_:_:)`` when Valhalla rejects the request or
+    ///   cannot match the trace, or a `DecodingError` when the response cannot be decoded.
+    public func traceRoute(request: MapMatchRequest) throws -> MapMatchRouteResponse {
+        try perform(request) { self.traceRoute(rawRequest: $0) }
+    }
+
+    /// Map-matches a GPS trace onto the road network and returns the attributes of every
+    /// edge along the matched path.
+    ///
+    /// Use this instead of ``traceRoute(request:)`` when you need the road network itself —
+    /// edge identifiers, road classes, speeds, names — rather than turn-by-turn directions.
+    /// Narrow the response with the request's `filters`; by default Valhalla returns every
+    /// attribute it has, which is a lot of JSON for a long trace.
+    ///
+    /// - Note: This action always answers with Valhalla's own JSON. The `format` option
+    ///   does not apply to it.
+    /// - Parameter request: the trace to match, the costing model, and which attributes to return.
+    /// - Returns: the matched edges, points, and the admins they reference.
+    /// - Throws: ``ValhallaError/valhallaError(_:_:)`` when Valhalla rejects the request or
+    ///   cannot match the trace, or a `DecodingError` when the response cannot be decoded.
+    public func traceAttributes(request: TraceAttributesRequest) throws -> TraceAttributesResponse {
+        try perform(request) { self.traceAttributes(rawRequest: $0) }
     }
 
     public func route(rawRequest request: String) -> String {
         actor!.route(request)
+    }
+
+    /// Runs a `trace_route` request supplied as JSON and returns the raw response.
+    ///
+    /// This is the escape hatch for response formats ``MapMatchRouteResponse`` cannot
+    /// model, and for request options the generated models do not yet carry.
+    /// Errors are returned in the body as `{"code": <int>, "message": "<string>"}`
+    /// rather than thrown.
+    public func traceRoute(rawRequest request: String) -> String {
+        actor!.traceRoute(request)
+    }
+
+    /// Runs a `trace_attributes` request supplied as JSON and returns the raw response.
+    ///
+    /// Errors are returned in the body as `{"code": <int>, "message": "<string>"}`
+    /// rather than thrown.
+    public func traceAttributes(rawRequest request: String) -> String {
+        actor!.traceAttributes(request)
+    }
+
+    /// Shared body of the typed actions: encode the request, run it, and decode the
+    /// response — surfacing the wrapper's error envelope as a thrown ``ValhallaError``.
+    ///
+    /// - Parameters:
+    ///   - request: the typed request to encode.
+    ///   - action: the raw action that carries the request across to the C++ wrapper.
+    private func perform<Request: Encodable, Response: Decodable>(
+        _ request: Request,
+        _ action: (String) -> String
+    ) throws -> Response {
+        let requestData = try JSONEncoder().encode(request)
+        guard let requestStr = String(data: requestData, encoding: .utf8) else {
+            throw ValhallaError.encodingNotUtf8("requestStr")
+        }
+
+        let resultStr = action(requestStr)
+        guard let resultData = resultStr.data(using: .utf8) else {
+            throw ValhallaError.encodingNotUtf8("resultData")
+        }
+
+        if let error = try? JSONDecoder().decode(ValhallaErrorModel.self, from: resultData) {
+            throw ValhallaError.valhallaError(error.code, error.message)
+        }
+
+        return try JSONDecoder().decode(Response.self, from: resultData)
     }
 }

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -131,12 +131,13 @@ using ActorAction = std::string (*)(const char*, void*);
 
 /// Shared body of every action method: hand the request to the C++ wrapper and
 /// bridge the response back. Callers hold the lock; this does not.
+///
+/// A null request is only reachable when a caller passes nil, which no Swift
+/// caller can do. It is reported the same way the C++ layer reports its own
+/// failures, rather than constructing a std::string from a null pointer.
 NSString* PerformAction(ActorAction action, NSString* request, void* actor) {
     const char* utf8Request = [request UTF8String];
     if (utf8Request == nullptr) {
-        // Only reachable when a caller passes nil, which no Swift caller can do.
-        // Report it the same way the C++ layer reports its own failures rather
-        // than constructing a std::string from a null pointer.
         return @"{\"code\":-1,\"message\":\"request was nil\"}";
     }
 

--- a/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
+++ b/apple/Sources/ValhallaObjc/ValhallaWrapper.mm
@@ -122,6 +122,32 @@ public:
 };
 
 
+namespace {
+
+/// One of the actor entry points in `main.h`. They all take a request and an actor,
+/// and they all answer with either a serialized response or the wrapper's error
+/// envelope — they never throw.
+using ActorAction = std::string (*)(const char*, void*);
+
+/// Shared body of every action method: hand the request to the C++ wrapper and
+/// bridge the response back. Callers hold the lock; this does not.
+NSString* PerformAction(ActorAction action, NSString* request, void* actor) {
+    const char* utf8Request = [request UTF8String];
+    if (utf8Request == nullptr) {
+        // Only reachable when a caller passes nil, which no Swift caller can do.
+        // Report it the same way the C++ layer reports its own failures rather
+        // than constructing a std::string from a null pointer.
+        return @"{\"code\":-1,\"message\":\"request was nil\"}";
+    }
+
+    std::string result = action(utf8Request, actor);
+
+    return [NSString stringWithUTF8String:result.c_str()];
+}
+
+} // namespace
+
+
 @implementation ValhallaWrapper
 
 - (instancetype)initWithConfigPath:(NSString*)config_path error:(__autoreleasing NSError **)error
@@ -152,13 +178,21 @@ public:
 - (NSString*)route:(NSString*)request
 {
     @synchronized(self) {
-        // Convert the NSString to std::string
-        std::string req = std::string([request UTF8String]);
-        
-        // Generate the valhalla response
-        std::string res = route(req.c_str(), _actor);
-        
-        return [NSString stringWithUTF8String:res.c_str()];
+        return PerformAction(&route, request, _actor);
+    }
+}
+
+- (NSString*)traceRoute:(NSString*)request
+{
+    @synchronized(self) {
+        return PerformAction(&trace_route, request, _actor);
+    }
+}
+
+- (NSString*)traceAttributes:(NSString*)request
+{
+    @synchronized(self) {
+        return PerformAction(&trace_attributes, request, _actor);
     }
 }
 

--- a/apple/Sources/ValhallaObjc/include/ValhallaWrapper.h
+++ b/apple/Sources/ValhallaObjc/include/ValhallaWrapper.h
@@ -14,6 +14,14 @@
 
 - (NSString*)route:(NSString*)request;
 
+/// Map-matches a GPS trace and returns a route along the matched path.
+/// @param request a `trace_route` request as JSON.
+- (NSString*)traceRoute:(NSString*)request;
+
+/// Map-matches a GPS trace and returns the attributes of every edge along the matched path.
+/// @param request a `trace_attributes` request as JSON.
+- (NSString*)traceAttributes:(NSString*)request;
+
 @end
 
 #endif /* ValhallaWrapperHeader_h */

--- a/apple/Tests/ValhallaTests/TestValhallaWithFolder.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithFolder.swift
@@ -50,4 +50,52 @@ final class TestValhallaWithFolder: XCTestCase {
         XCTAssertEqual(response.trip.statusMessage, "Found route between points")
         XCTAssertEqual(response.trip.legs.first?.shape.count, 656)
     }
+
+    /// The shape of a known-good route through the fixture, as a polyline with six digits of
+    /// precision — which is what the trace actions expect.
+    private func routeShape(_ valhalla: Valhalla) throws -> String {
+        let request = RouteRequest(
+            locations: [
+                RoutingWaypoint(lat: 42.5063, lon: 1.5218),
+                RoutingWaypoint(lat: 42.5086, lon: 1.5394)
+            ],
+            costing: .auto,
+            units: .mi,
+        )
+
+        let response = try valhalla.route(request: request)
+
+        return try XCTUnwrap(response.trip.legs.first?.shape)
+    }
+
+    /// Validate that map matching also works against a tile directory, not just a tile extract.
+    func testSuccessfulTraceRoute() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = MapMatchRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto
+        )
+
+        let response = try valhalla.traceRoute(request: request)
+
+        XCTAssertEqual(response.trip.status, 0)
+        XCTAssertEqual(response.trip.statusMessage, "Found route between points")
+        XCTAssertFalse(response.trip.legs.isEmpty)
+    }
+
+    /// Validate that trace attributes also work against a tile directory.
+    func testSuccessfulTraceAttributes() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = TraceAttributesRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto
+        )
+
+        let response = try valhalla.traceAttributes(request: request)
+
+        XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
+        XCTAssertNotNil(response.shape)
+    }
 }

--- a/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
@@ -158,10 +158,14 @@ final class TestValhallaWithTar: XCTestCase {
 
     /// Validate the map-snapping path, which is the one that reports how each input point matched.
     ///
-    /// `matched.edge_index` has to be excluded. Valhalla never populates it for `trace_attributes`
-    /// — the serializer carries a TODO saying as much — so it emits the `size_t` sentinel,
-    /// 18446744073709551615, which no signed 64-bit type can hold. Requesting it makes the whole
-    /// response undecodable rather than just that one field.
+    /// `matched.edge_index` has to be excluded. Valhalla leaves it unpopulated for some matched
+    /// points in `trace_attributes` while still reporting a valid edge id, so it serializes the
+    /// `size_t` sentinel, 18446744073709551615, which no signed 64-bit type can hold. Requesting
+    /// it makes the whole response undecodable rather than just that one field.
+    ///
+    /// Tracked upstream as valhalla/valhalla#3699, with a fix proposed in valhalla/valhalla#6278.
+    /// Drop the filter once the submodule is bumped past that fix — if this test then passes
+    /// unfiltered, the workaround and the notes on ``Valhalla/traceAttributes(request:)`` can go.
     func testMapSnapTraceAttributes() throws {
         let valhalla = try Valhalla(defaultConfig)
 

--- a/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
@@ -74,4 +74,102 @@ final class TestValhallaWithTar: XCTestCase {
         XCTAssertEqual(response.trip.statusMessage, "Found route between points")
         XCTAssertEqual(response.trip.legs.first?.shape.count, 656)
     }
+
+    /// The shape of a known-good route through the fixture, as a polyline with six digits of
+    /// precision — which is what the trace actions expect.
+    ///
+    /// Taking the trace off the graph itself, rather than writing coordinates by hand, keeps the
+    /// map matching tests about matching instead of about how faithfully some invented points
+    /// happen to sit on an Andorran road.
+    private func routeShape(_ valhalla: Valhalla) throws -> String {
+        let request = RouteRequest(
+            locations: [
+                RoutingWaypoint(lat: 42.5063, lon: 1.5218),
+                RoutingWaypoint(lat: 42.5086, lon: 1.5394)
+            ],
+            costing: .auto,
+            units: .mi,
+        )
+
+        let response = try valhalla.route(request: request)
+
+        return try XCTUnwrap(response.trip.legs.first?.shape)
+    }
+
+    /// Validate a successful map match that returns a route along the matched path.
+    func testSuccessfulTraceRoute() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = MapMatchRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto
+        )
+
+        let response = try valhalla.traceRoute(request: request)
+
+        XCTAssertEqual(response.trip.status, 0)
+        XCTAssertEqual(response.trip.statusMessage, "Found route between points")
+        XCTAssertFalse(response.trip.legs.isEmpty)
+    }
+
+    /// Validate a valhalla error when the trace is nowhere near the tiles we have.
+    func testTraceRouteNoMatch() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = MapMatchRequest(
+            shape: [
+                MapMatchWaypoint(lat: 45.843812, lon: -123.768205),
+                MapMatchWaypoint(lat: 45.869701, lon: -123.766121)
+            ],
+            costing: .auto
+        )
+
+        do {
+            let _ = try valhalla.traceRoute(request: request)
+            XCTFail("traceRoute should throw for a trace outside the tiles")
+        } catch let error as ValhallaError {
+            // Which code comes back depends on how far the matcher gets before giving up — Loki
+            // can reject the locations outright, or Meili can fail to find a path — so assert
+            // that the engine reported a failure rather than pinning a code that isn't ours.
+            guard case .valhallaError = error else {
+                return XCTFail("expected a valhalla error, got \(error)")
+            }
+        }
+    }
+
+    /// Validate a successful map match that returns the attributes of the matched edges.
+    func testSuccessfulTraceAttributes() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = TraceAttributesRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto
+        )
+
+        let response = try valhalla.traceAttributes(request: request)
+
+        XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(response.matchedPoints).isEmpty)
+        XCTAssertNotNil(response.shape)
+    }
+
+    /// Validate that a filter narrows the response to just the attributes that were asked for.
+    func testFilteredTraceAttributes() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = TraceAttributesRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto,
+            filters: TraceAttributeFilterOptions(
+                attributes: [.edgePeriodSpeed, .edgePeriodNames],
+                action: .include
+            )
+        )
+
+        let response = try valhalla.traceAttributes(request: request)
+
+        XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
+        // The shape was not among the requested attributes, so it should not come back.
+        XCTAssertNil(response.shape)
+    }
 }

--- a/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
@@ -113,6 +113,9 @@ final class TestValhallaWithTar: XCTestCase {
     }
 
     /// Validate a valhalla error when the trace is nowhere near the tiles we have.
+    ///
+    /// The code is not pinned: it depends on how far the matcher gets before giving up, since Loki
+    /// can reject the locations outright and Meili can fail to find a path.
     func testTraceRouteNoMatch() throws {
         let valhalla = try Valhalla(defaultConfig)
 
@@ -128,9 +131,6 @@ final class TestValhallaWithTar: XCTestCase {
             let _ = try valhalla.traceRoute(request: request)
             XCTFail("traceRoute should throw for a trace outside the tiles")
         } catch let error as ValhallaError {
-            // Which code comes back depends on how far the matcher gets before giving up — Loki
-            // can reject the locations outright, or Meili can fail to find a path — so assert
-            // that the engine reported a failure rather than pinning a code that isn't ours.
             guard case .valhallaError = error else {
                 return XCTFail("expected a valhalla error, got \(error)")
             }
@@ -138,6 +138,9 @@ final class TestValhallaWithTar: XCTestCase {
     }
 
     /// Validate a successful map match that returns the attributes of the matched edges.
+    ///
+    /// The trace is the exact shape of a prior route, so Valhalla walks the edges instead of
+    /// running Meili, and there are no `matchedPoints` — `testMapSnapTraceAttributes` covers those.
     func testSuccessfulTraceAttributes() throws {
         let valhalla = try Valhalla(defaultConfig)
 
@@ -149,8 +152,24 @@ final class TestValhallaWithTar: XCTestCase {
         let response = try valhalla.traceAttributes(request: request)
 
         XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
-        XCTAssertFalse(try XCTUnwrap(response.matchedPoints).isEmpty)
         XCTAssertNotNil(response.shape)
+        XCTAssertNil(response.matchedPoints)
+    }
+
+    /// Validate the map-snapping path, which is the one that reports how each input point matched.
+    func testMapSnapTraceAttributes() throws {
+        let valhalla = try Valhalla(defaultConfig)
+
+        let request = TraceAttributesRequest(
+            encodedPolyline: try routeShape(valhalla),
+            costing: .auto,
+            shapeMatch: .mapSnap
+        )
+
+        let response = try valhalla.traceAttributes(request: request)
+
+        XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(response.matchedPoints).isEmpty)
     }
 
     /// Validate that a filter narrows the response to just the attributes that were asked for.
@@ -169,7 +188,6 @@ final class TestValhallaWithTar: XCTestCase {
         let response = try valhalla.traceAttributes(request: request)
 
         XCTAssertFalse(try XCTUnwrap(response.edges).isEmpty)
-        // The shape was not among the requested attributes, so it should not come back.
         XCTAssertNil(response.shape)
     }
 }

--- a/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
+++ b/apple/Tests/ValhallaTests/TestValhallaWithTar.swift
@@ -157,13 +157,22 @@ final class TestValhallaWithTar: XCTestCase {
     }
 
     /// Validate the map-snapping path, which is the one that reports how each input point matched.
+    ///
+    /// `matched.edge_index` has to be excluded. Valhalla never populates it for `trace_attributes`
+    /// — the serializer carries a TODO saying as much — so it emits the `size_t` sentinel,
+    /// 18446744073709551615, which no signed 64-bit type can hold. Requesting it makes the whole
+    /// response undecodable rather than just that one field.
     func testMapSnapTraceAttributes() throws {
         let valhalla = try Valhalla(defaultConfig)
 
         let request = TraceAttributesRequest(
             encodedPolyline: try routeShape(valhalla),
             costing: .auto,
-            shapeMatch: .mapSnap
+            shapeMatch: .mapSnap,
+            filters: TraceAttributeFilterOptions(
+                attributes: [.matchedPeriodEdgeIndex],
+                action: .exclude
+            )
         )
 
         let response = try valhalla.traceAttributes(request: request)

--- a/src/wrapper/include/main.h
+++ b/src/wrapper/include/main.h
@@ -16,6 +16,16 @@ JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv
                                                 jstring jRequest,
                                                 jstring jConfigPath);
 
+JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_traceRoute(JNIEnv *env,
+                                                jobject thiz,
+                                                jstring jRequest,
+                                                jstring jConfigPath);
+
+JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_traceAttributes(JNIEnv *env,
+                                                jobject thiz,
+                                                jstring jRequest,
+                                                jstring jConfigPath);
+
 #ifdef __cplusplus
 }
 #endif
@@ -23,6 +33,8 @@ JNIEXPORT jstring JNICALL Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv
 #elif __APPLE__
 
 std::string route(const char *request, void* actor);
+std::string trace_route(const char *request, void* actor);
+std::string trace_attributes(const char *request, void* actor);
 void* create_valhalla_actor(const char *config_path, ValhallaMobileHttpClient* http_client = nullptr);
 void delete_valhalla_actor(void* actor);
 

--- a/src/wrapper/include/valhalla_actor.h
+++ b/src/wrapper/include/valhalla_actor.h
@@ -35,8 +35,32 @@ private:
     std::unique_ptr<valhalla::baldr::GraphReader> graph_reader;
 public:
     ValhallaActor(const std::string& config_path, ValhallaMobileHttpClient* http_client = nullptr);
-    
+
     std::string route(const std::string& request);
+
+    /**
+     * Map-match a GPS trace onto the road network and return a route along the
+     * matched path. This is Valhalla's `trace_route` action.
+     *
+     * @param request  a `trace_route` request as JSON. See
+     *                 https://valhalla.github.io/valhalla/api/map-matching/api-reference/
+     * @return         the serialized response, in whichever format the request asked for
+     */
+    std::string trace_route(const std::string& request);
+
+    /**
+     * Map-match a GPS trace onto the road network and return the attributes of
+     * every edge along the matched path. This is Valhalla's `trace_attributes`
+     * action.
+     *
+     * Unlike `trace_route`, this action always answers with Valhalla's own JSON —
+     * the `format` option does not apply to it.
+     *
+     * @param request  a `trace_attributes` request as JSON. See
+     *                 https://valhalla.github.io/valhalla/api/map-matching/api-reference/
+     * @return         the serialized JSON response
+     */
+    std::string trace_attributes(const std::string& request);
 };
 
 #endif // VALHALLAACTOR_H

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -3,9 +3,161 @@
 #include "main.h"
 #include "valhalla_actor.h"
 
+#include <cstdio>
+#include <string>
+
+namespace {
+
+/**
+ * Escapes a string so it can be embedded in a JSON string literal.
+ *
+ * Exception messages are not ours: they come from Valhalla and from the C++
+ * runtime, and can carry quotes or backslashes — a config path echoed back by
+ * `Cannot open file ...`, for instance. Concatenating one of those into a JSON
+ * literal unescaped produces a payload the Swift and Kotlin decoders cannot
+ * parse, turning a legible routing error into a decoding failure.
+ */
+std::string escape_json(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (const char c : value) {
+        switch (c) {
+            case '"': escaped += "\\\""; break;
+            case '\\': escaped += "\\\\"; break;
+            case '\b': escaped += "\\b"; break;
+            case '\f': escaped += "\\f"; break;
+            case '\n': escaped += "\\n"; break;
+            case '\r': escaped += "\\r"; break;
+            case '\t': escaped += "\\t"; break;
+            default:
+                // Everything else below the space is a control character, which JSON
+                // only permits in \u form. Bytes at or above 0x20 — including UTF-8
+                // continuation bytes — pass through untouched.
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buffer[7];
+                    std::snprintf(buffer, sizeof(buffer), "\\u%04x", c);
+                    escaped += buffer;
+                } else {
+                    escaped += c;
+                }
+        }
+    }
+    return escaped;
+}
+
+/**
+ * Builds the error envelope every platform layer parses: `{"code":<int>,"message":"<string>"}`.
+ *
+ * @param code     Valhalla's error code, or -1 for failures raised outside Valhalla
+ * @param message  human readable description of the failure
+ */
+std::string error_json(long long code, const std::string& message) {
+    return "{\"code\":" + std::to_string(code) + ",\"message\":\"" + escape_json(message) + "\"}";
+}
+
+/**
+ * Runs one actor action, converting every C++ exception into the error envelope.
+ *
+ * No C++ exception may cross the JNI or Obj-C++ boundary, so all three catch
+ * clauses are mandatory on every entry point — this wrapper is what keeps them
+ * from drifting apart as actions are added.
+ *
+ * @param action_name  the action being run, used only for debug logging
+ * @param action       callable producing the serialized response
+ */
+template <typename Action>
+std::string invoke_action(const char* action_name, Action&& action) {
+    try {
+        return action();
+    } catch (const valhalla::valhalla_exception_t &err) {
+        printf("[ValhallaActor] %s valhalla_exception: %s\n", action_name, err.what());
+        return error_json(static_cast<long long>(err.code), err.message);
+    } catch (const std::exception &err) {
+        printf("[ValhallaActor] %s std::exception: %s\n", action_name, err.what());
+        return error_json(-1, err.what());
+    } catch (...) {
+        printf("[ValhallaActor] %s unknown exception\n", action_name);
+        return error_json(-1, "unknown exception");
+    }
+}
+
+// Pointer to one of the ValhallaActor action methods, all of which share a signature.
+using ActorAction = std::string (ValhallaActor::*)(const std::string&);
+
+} // namespace
+
 #ifdef __ANDROID__
 // The Android JNI interface uses a different function signature.
 #include <jni.h>
+
+namespace {
+
+/**
+ * Borrows a Java string's UTF-8 characters for the duration of a scope.
+ *
+ * Hand-written release calls are easy to skip on an early return, and the JNI
+ * entry points below have several. Tying the release to scope exit also keeps
+ * it correct if a future change lets something unwind out of the middle.
+ */
+class ScopedUtfChars {
+public:
+    ScopedUtfChars(JNIEnv* env, jstring value)
+        : env(env), value(value), chars(env->GetStringUTFChars(value, nullptr)) {
+    }
+
+    ~ScopedUtfChars() {
+        if (chars) {
+            env->ReleaseStringUTFChars(value, chars);
+        }
+    }
+
+    ScopedUtfChars(const ScopedUtfChars&) = delete;
+    ScopedUtfChars& operator=(const ScopedUtfChars&) = delete;
+
+    // Null when the JVM could not allocate the copy, in which case it has already
+    // thrown OutOfMemoryError on this thread.
+    const char* get() const {
+        return chars;
+    }
+
+private:
+    JNIEnv* env;
+    jstring value;
+    const char* chars;
+};
+
+/**
+ * Shared body of every JNI entry point: read the Java strings, build an actor,
+ * run one action against it, and hand the response back as a Java string.
+ */
+jstring run_jni_action(JNIEnv *env,
+                       jstring jRequest,
+                       jstring jConfigPath,
+                       ActorAction action,
+                       const char* action_name) {
+    ScopedUtfChars request(env, jRequest);
+    ScopedUtfChars config_path(env, jConfigPath);
+
+    std::string result;
+    if (request.get() == nullptr || config_path.get() == nullptr) {
+        // A pending OutOfMemoryError would be thrown into Kotlin the moment we
+        // return, in place of the String this method promises. Clear it and
+        // report through the envelope callers already know how to handle.
+        env->ExceptionClear();
+        result = error_json(-1, std::string("failed to read the ") + action_name +
+                                    " request from the JVM");
+    } else {
+        result = invoke_action(action_name, [&]() {
+            // TODO: Android currently creates a new actor every time. Optimize to be like iOS later.
+            ValhallaActor valhallaActor(config_path.get());
+            return (valhallaActor.*action)(request.get());
+        });
+    }
+
+    return env->NewStringUTF(result.c_str());
+}
+
+} // namespace
 
 extern "C"
 JNIEXPORT jstring
@@ -15,33 +167,30 @@ Java_com_valhalla_valhalla_ValhallaKotlin_route(JNIEnv *env,
                                                 jobject thiz,
                                                 jstring jRequest,
                                                 jstring jConfigPath) {
-    
-    const char *request = env->GetStringUTFChars(jRequest, 0);
-    const char *config_path = env->GetStringUTFChars(jConfigPath, 0);
+    return run_jni_action(env, jRequest, jConfigPath, &ValhallaActor::route, "route");
+}
 
-    std::string result;
-    try {
-        // TODO: Android currently creates a new actor every time. Optimize to be like iOS later.
-        ValhallaActor valhallaActor(config_path);
-        result = valhallaActor.route(request);
-    } catch (const valhalla::valhalla_exception_t &err) {
-        printf("[ValhallaActor] route valhalla_exception: %s\n", err.what());
-        std::string code = std::to_string(err.code);
-        std::string message = err.message.c_str();
+extern "C"
+JNIEXPORT jstring
 
-        result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
-    } catch (const std::exception &err) {
-        printf("[ValhallaActor] route std::exception: %s\n", err.what());
-        result = "{\"code\":-1,\"message\":\"" + std::string(err.what()) + "\"}";
-    } catch (...) {
-        printf("[ValhallaActor] route unknown exception");
-        result = "{\"code\":-1,\"message\":\"unknown exception\"}";
-    }
+JNICALL
+Java_com_valhalla_valhalla_ValhallaKotlin_traceRoute(JNIEnv *env,
+                                                     jobject thiz,
+                                                     jstring jRequest,
+                                                     jstring jConfigPath) {
+    return run_jni_action(env, jRequest, jConfigPath, &ValhallaActor::trace_route, "trace_route");
+}
 
-    env->ReleaseStringUTFChars(jRequest, request);
-    env->ReleaseStringUTFChars(jConfigPath, config_path);
+extern "C"
+JNIEXPORT jstring
 
-    return env->NewStringUTF(result.c_str());
+JNICALL
+Java_com_valhalla_valhalla_ValhallaKotlin_traceAttributes(JNIEnv *env,
+                                                          jobject thiz,
+                                                          jstring jRequest,
+                                                          jstring jConfigPath) {
+    return run_jni_action(env, jRequest, jConfigPath, &ValhallaActor::trace_attributes,
+                          "trace_attributes");
 }
 
 #elif __APPLE__
@@ -54,23 +203,20 @@ void delete_valhalla_actor(void* actor) {
 }
 
 std::string route(const char *request, void* actor) {
-    std::string result;
-    try {
-        result = ((ValhallaActor*) actor)->route(request);
-    } catch (const valhalla::valhalla_exception_t &err) {
-        printf("[ValhallaActor] route valhalla_exception: %s\n", err.what());
-        std::string code = std::to_string(err.code);
-        std::string message = err.message.c_str();
+    return invoke_action("route", [&]() {
+        return ((ValhallaActor*) actor)->route(request);
+    });
+}
 
-        result = "{\"code\":" + code + ",\"message\":\"" + message + "\"}";
-    } catch (const std::exception &err) {
-        printf("[ValhallaActor] route std::exception: %s\n", err.what());
-        result = "{\"code\":-1,\"message\":\"" + std::string(err.what()) + "\"}";
-    } catch (...) {
-        printf("[ValhallaActor] route unknown exception");
-        result = "{\"code\":-1,\"message\":\"unknown exception\"}";
-    }
+std::string trace_route(const char *request, void* actor) {
+    return invoke_action("trace_route", [&]() {
+        return ((ValhallaActor*) actor)->trace_route(request);
+    });
+}
 
-    return result;
+std::string trace_attributes(const char *request, void* actor) {
+    return invoke_action("trace_attributes", [&]() {
+        return ((ValhallaActor*) actor)->trace_attributes(request);
+    });
 }
 #endif

--- a/src/wrapper/main.cpp
+++ b/src/wrapper/main.cpp
@@ -16,6 +16,10 @@ namespace {
  * `Cannot open file ...`, for instance. Concatenating one of those into a JSON
  * literal unescaped produces a payload the Swift and Kotlin decoders cannot
  * parse, turning a legible routing error into a decoding failure.
+ *
+ * Everything below the space is a control character, which JSON only permits in
+ * \u form. Bytes at or above 0x20 — including UTF-8 continuation bytes — pass
+ * through untouched.
  */
 std::string escape_json(const std::string& value) {
     std::string escaped;
@@ -30,9 +34,6 @@ std::string escape_json(const std::string& value) {
             case '\r': escaped += "\\r"; break;
             case '\t': escaped += "\\t"; break;
             default:
-                // Everything else below the space is a control character, which JSON
-                // only permits in \u form. Bytes at or above 0x20 — including UTF-8
-                // continuation bytes — pass through untouched.
                 if (static_cast<unsigned char>(c) < 0x20) {
                     char buffer[7];
                     std::snprintf(buffer, sizeof(buffer), "\\u%04x", c);
@@ -129,6 +130,11 @@ private:
 /**
  * Shared body of every JNI entry point: read the Java strings, build an actor,
  * run one action against it, and hand the response back as a Java string.
+ *
+ * A null from either ScopedUtfChars means a pending OutOfMemoryError, which
+ * would be thrown into Kotlin the moment we return, in place of the String this
+ * method promises. It is cleared and reported through the envelope callers
+ * already know how to handle.
  */
 jstring run_jni_action(JNIEnv *env,
                        jstring jRequest,
@@ -140,9 +146,6 @@ jstring run_jni_action(JNIEnv *env,
 
     std::string result;
     if (request.get() == nullptr || config_path.get() == nullptr) {
-        // A pending OutOfMemoryError would be thrown into Kotlin the moment we
-        // return, in place of the String this method promises. Clear it and
-        // report through the envelope callers already know how to handle.
         env->ExceptionClear();
         result = error_json(-1, std::string("failed to read the ") + action_name +
                                     " request from the JVM");

--- a/src/wrapper/valhalla_actor.cpp
+++ b/src/wrapper/valhalla_actor.cpp
@@ -86,9 +86,17 @@ std::string config_file(config_path);
 std::string ValhallaActor::route(const std::string& request) {
     // Convert the request to a std::string
     std::string req = std::string(request);
-    
+
     // Produce the route result
     std::string result = actor->route(req);
-    
+
     return result;
+}
+
+std::string ValhallaActor::trace_route(const std::string& request) {
+    return actor->trace_route(request);
+}
+
+std::string ValhallaActor::trace_attributes(const std::string& request) {
+    return actor->trace_attributes(request);
 }


### PR DESCRIPTION
Mostly vibe-coded, but I looked at the code at it looks reasonable.
JSON exception was added to support the following issue:
"the old envelope concatenated exception messages raw, so a quote or backslash in one produced JSON the platform decoders couldn't parse"

It might be too much, so let me know if you want it in or not.

I've updated the relevant readmes and added some tests.
Let me know if there's anything worth changing to be able to merge this.

- Resolves #64 
- Similar to #93
- Similar to #83
- Requires: https://github.com/Rallista/valhalla-openapi-models-kotlin/pull/27
- Optional, but related: https://github.com/Rallista/valhalla-openapi-models-swift/pull/13